### PR TITLE
Do not use a custom path by default in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 unless ENV['TRAVIS']
   gem 'byebug',      require: false, platforms: :ruby
   gem 'yard',        require: false
-  gem 'lotus-utils', require: false, path: '../lotus-utils'
+  gem 'lotus-utils', require: false
 end
 
 gem 'simplecov', require: false


### PR DESCRIPTION
I don't think that using a custom path by default is what users would expect when trying to use the project. 

I was trying to run the specs and got this error message.

```
The path `/Users/marcos/Proyectos/lotus/lotus-utils` does not exist.
```

That change should fix the problem. Should this be applied to other lotus projects or is this an error from my side?

Thanks!
