### PR TITLE
Review exceptions

### DIFF
--- a/test/integration/client_error_test.rb
+++ b/test/integration/client_error_test.rb
@@ -2,7 +2,11 @@ require 'test_helper'
 
 describe Lotus::Router do
   before do
-    @router = Lotus::Router.new { get '/', to: ->(env) {} }
+    @router = Lotus::Router.new do
+      get '/', to: ->(env) {}
+      get '/dashboard', to: 'this#does_not_exist'
+      get '/some_exception', to: ->(env) { raise StandardError('Hello') }
+    end
     @app    = Rack::MockRequest.new(@router)
   end
 
@@ -12,5 +16,13 @@ describe Lotus::Router do
 
   it 'returns 405 for unacceptable HTTP method' do
     @app.post('/').status.must_equal 405
+  end
+
+  it 'returns 500 if the endpoint is not found' do
+    @app.post('/dashboard').status.must_equal 500
+  end
+
+  it 'returns 500 if the endpoint raises an exception' do
+    @app.post('/some_exception').status.must_equal 500
   end
 end


### PR DESCRIPTION
Hi,

If the Endpoint specified in the routes cannot be resolved or an exception is raised, the http status code should default to 500 Internal Server Error. Right now it sends a 405 Method Not Allowed. 

I think a 500 is the one to use because the developer clearly specified that the route exist – thus the method and path are allowed – but failed to implement it correctly, causing an Internal Server Error. 

What do you think?

I implemented the tests for this and I gave it a try to make it green but I wasn't sure where should I put the code to handle those cases. 
