### PR TITLE
Switch to Ruby's native JSON parser

### DIFF
--- a/lib/lotus/routing/parsing/json_parser.rb
+++ b/lib/lotus/routing/parsing/json_parser.rb
@@ -1,4 +1,4 @@
-require 'rack/utils/okjson'
+require 'json'
 
 module Lotus
   module Routing
@@ -9,7 +9,7 @@ module Lotus
         end
 
         def parse(body)
-          Rack::Utils::OkJson.decode(body)
+          JSON.parse(body)
         end
       end
     end


### PR DESCRIPTION
Ruby's JSON parser is ~20x faster, because it's written in C.

```
Calculating -------------------------------------
                ruby       204 i/100ms
                rack         6 i/100ms
-------------------------------------------------
                ruby     2071.8 (±5.1%) i/s -      10404 in   5.034635s
                rack       68.6 (±4.4%) i/s -        342 in   5.001516s
```
