### PR TITLE
Make 301 the default redirect status

### DIFF
--- a/lib/lotus/router.rb
+++ b/lib/lotus/router.rb
@@ -461,7 +461,7 @@ module Lotus
     #
     # @param path [String] the path that needs to be redirected
     # @param options [Hash] the options to customize the redirect behavior
-    # @option options [Fixnum] the HTTP status to return (defaults to `302`)
+    # @option options [Fixnum] the HTTP status to return (defaults to `301`)
     #
     # @return [Lotus::Routing::Route] the generated route.
     #   This may vary according to the `:route` option passed to the initializer
@@ -475,7 +475,7 @@ module Lotus
     #
     #   Lotus::Router.new do
     #     redirect '/legacy',  to: '/new_endpoint'
-    #     redirect '/legacy2', to: '/new_endpoint2', code: 301
+    #     redirect '/legacy2', to: '/new_endpoint2', code: 302
     #   end
     #
     # @example
@@ -484,7 +484,7 @@ module Lotus
     #   router = Lotus::Router.new
     #   router.redirect '/legacy',  to: '/new_endpoint'
     def redirect(path, options = {}, &endpoint)
-      get(path).redirect @router.find(options), options[:code] || 302
+      get(path).redirect @router.find(options), options[:code] || 301
     end
 
     # Defines a Ruby block: all the routes defined within it will be namespaced

--- a/test/namespace_test.rb
+++ b/test/namespace_test.rb
@@ -95,7 +95,7 @@ describe Lotus::Router do
 
       it 'recognizes get path' do
         @app.request('GET', '/users/dashboard').headers['Location'].must_equal '/users/home'
-        @app.request('GET', '/users/dashboard').status.must_equal 302
+        @app.request('GET', '/users/dashboard').status.must_equal 301
       end
     end
 

--- a/test/redirect_test.rb
+++ b/test/redirect_test.rb
@@ -14,19 +14,19 @@ describe Lotus::Router do
       env = Rack::MockRequest.env_for('/redirect')
       status, headers, _ = @router.call(env)
 
-      status.must_equal 302
+      status.must_equal 301
       headers['Location'].must_equal '/redirect_destination'
     end
 
     it 'recognizes string endpoint with custom http code' do
       endpoint = ->(env) { [200, {}, ['Redirect destination!']] }
       @router.get('/redirect_destination', to: endpoint)
-      @router.redirect('/redirect', to: '/redirect_destination', code: 301)
+      @router.redirect('/redirect', to: '/redirect_destination', code: 302)
 
       env = Rack::MockRequest.env_for('/redirect')
       status, headers, _ = @router.call(env)
 
-      status.must_equal 301
+      status.must_equal 302
       headers['Location'].must_equal '/redirect_destination'
     end
   end


### PR DESCRIPTION
When users make a redirect in the router level, they usually mean "permanent", because there is no conditional.

And in the controller level it makes sense to use 302, because in there it's very likely that it's just a temprary redirect.

I always liked that Rails does it this way, and I think it makes a lot of sense for Lotus to do it to.
