### PR TITLE
Unify namespaced routes syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,6 @@ router.namespace 'animals' do
   end
 end
 
-# or
-
-router.get '/cats', prefix: '/animals/mammals', to:->(env) { [200, {}, ['Meow!']] }, as: :cats
-
 # and it generates:
 
 router.path(:animals_mammals_cats) # => "/animals/mammals/cats"

--- a/lib/lotus/router.rb
+++ b/lib/lotus/router.rb
@@ -49,19 +49,6 @@ module Lotus
   #
   #
   #
-  # @example Specify a prefix with `:prefix`
-  #   require 'lotus/router'
-  #
-  #   endpoint = ->(env) { [200, {}, ['Welcome to Lotus::Router!']] }
-  #   router = Lotus::Router.new do
-  #     get '/welcome', to: endpoint, prefix: 'dashboard' # => '/dashboard/welcome'
-  #   end
-  #
-  #   # :prefix isn't mandatory for the default resolver (`Lotus::Routing::EndpointResolver.new`),
-  #   # This behavior can be changed by passing a custom resolver to `Lotus::Router#initialize`
-  #
-  #
-  #
   # @example Specify a named route with `:as`
   #   require 'lotus/router'
   #
@@ -213,7 +200,6 @@ module Lotus
     #
     # @param options [Hash] the options to customize the route
     # @option options [String,Proc,Class,Object#call] :to the endpoint
-    # @option options [String] :prefix an optional path prefix
     #
     # @param blk [Proc] the anonymous proc to be used as endpoint for the route
     #
@@ -282,17 +268,6 @@ module Lotus
     #   router.path(:lotus) # => "/lotus"
     #   router.url(:lotus)  # => "https://lotusrb.org/lotus"
     #
-    # @example Prefixed routes
-    #   require 'lotus/router'
-    #
-    #   router = Lotus::Router.new
-    #   router.get '/cats',
-    #     prefix: '/animals/mammals',
-    #     to: ->(env) { [200, {}, ['Meow!']] },
-    #     as: :cats
-    #
-    #   router.path(:animals_mammals_cats) # => "/animals/mammals/cats"
-    #
     # @example Duck typed endpoints (Rack compatible objects)
     #   require 'lotus/router'
     #
@@ -343,7 +318,6 @@ module Lotus
     #
     # @param options [Hash] the options to customize the route
     # @option options [String,Proc,Class,Object#call] :to the endpoint
-    # @option options [String] :prefix an optional path prefix
     #
     # @param blk [Proc] the anonymous proc to be used as endpoint for the route
     #
@@ -363,7 +337,6 @@ module Lotus
     #
     # @param options [Hash] the options to customize the route
     # @option options [String,Proc,Class,Object#call] :to the endpoint
-    # @option options [String] :prefix an optional path prefix
     #
     # @param blk [Proc] the anonymous proc to be used as endpoint for the route
     #
@@ -383,7 +356,6 @@ module Lotus
     #
     # @param options [Hash] the options to customize the route
     # @option options [String,Proc,Class,Object#call] :to the endpoint
-    # @option options [String] :prefix an optional path prefix
     #
     # @param blk [Proc] the anonymous proc to be used as endpoint for the route
     #
@@ -403,7 +375,6 @@ module Lotus
     #
     # @param options [Hash] the options to customize the route
     # @option options [String,Proc,Class,Object#call] :to the endpoint
-    # @option options [String] :prefix an optional path prefix
     #
     # @param blk [Proc] the anonymous proc to be used as endpoint for the route
     #
@@ -423,7 +394,6 @@ module Lotus
     #
     # @param options [Hash] the options to customize the route
     # @option options [String,Proc,Class,Object#call] :to the endpoint
-    # @option options [String] :prefix an optional path prefix
     #
     # @param blk [Proc] the anonymous proc to be used as endpoint for the route
     #
@@ -443,7 +413,6 @@ module Lotus
     #
     # @param options [Hash] the options to customize the route
     # @option options [String,Proc,Class,Object#call] :to the endpoint
-    # @option options [String] :prefix an optional path prefix
     #
     # @param blk [Proc] the anonymous proc to be used as endpoint for the route
     #
@@ -488,11 +457,12 @@ module Lotus
     end
 
     # Defines a Ruby block: all the routes defined within it will be namespaced
-    #   with the given prefix.
+    # with the given relative path.
     #
     # Namespaces blocks can be nested multiple times.
     #
-    # @param prefix [String] the path prefix
+    # @param namespace [String] the relative path where the nested routes will
+    #   be mounted
     # @param blk [Proc] the block that defines the resources
     #
     # @return [Lotus::Routing::Namespace] the generated namespace.
@@ -508,10 +478,6 @@ module Lotus
     #     namespace 'trees' do
     #       get '/sequoia', to: endpoint # => '/trees/sequoia'
     #     end
-    #
-    #     # equivalent to
-    #
-    #     get '/sequoia', to: endpoint, prefix: 'trees' # => '/trees/sequoia'
     #   end
     #
     # @example Nested namespaces
@@ -532,8 +498,8 @@ module Lotus
     #   router.namespace 'trees' do
     #     get '/sequoia', to: endpoint # => '/trees/sequoia'
     #   end
-    def namespace(prefix, &blk)
-      Routing::Namespace.new(self, prefix, &blk)
+    def namespace(namespace, &blk)
+      Routing::Namespace.new(self, namespace, &blk)
     end
 
     # Defines a set of named routes for a single RESTful resource.
@@ -792,7 +758,7 @@ module Lotus
     #
     # @param app [#call] a class or an object that responds to #call
     # @param options [Hash] the options to customize the mount
-    # @option options [:at] the path prefix where to mount the app
+    # @option options [:at] the relative path where to mount the app
     #
     # @since 0.1.1
     #

--- a/lib/lotus/routing/endpoint_resolver.rb
+++ b/lib/lotus/routing/endpoint_resolver.rb
@@ -156,7 +156,7 @@ module Lotus
       # @param options [Hash] the options required to resolve the endpoint
       #
       # @option options [String,Proc,Class,Object#call] :to the endpoint
-      # @option options [String] :prefix an optional path prefix
+      # @option options [String] :namespace an optional routing namespace
       #
       # @return [Endpoint] this may vary according to the :endpoint option
       #   passed to #initialize
@@ -196,12 +196,16 @@ module Lotus
       #   router = Lotus::Router.new
       #   router.get '/', to: ArticlesController::Show
       #
-      # @example Resolve with a path prefix
+      # @example Resolve a redirect with a namespace
       #   require 'lotus/router'
       #
       #   router = Lotus::Router.new
-      #   router.get '/dashboard', to: BackendApp.new, prefix: 'backend'
-      #     # => Will be available under '/backend/dashboard'
+      #   router.namespace 'users' do
+      #     get '/home',           to: ->(env) { ... }
+      #     redirect '/dashboard', to: '/home'
+      #   end
+      #
+      #   # GET /users/dashboard => 301 Location: "/users/home"
       def resolve(options, &endpoint)
         result = endpoint || find(options)
         resolve_callable(result) || resolve_matchable(result) || default
@@ -211,14 +215,14 @@ module Lotus
       #
       # @param options [Hash] the path description
       # @option options [String,Proc,Class,Object#call] :to the endpoint
-      # @option options [String] :prefix an optional path prefix
+      # @option options [String] :namespace an optional namespace
       #
       # @since 0.1.0
       #
       # @return [Object]
       def find(options)
-        if prefix = options[:prefix]
-          prefix.join(options[:to])
+        if namespace = options[:namespace]
+          namespace.join(options[:to])
         else
           options[:to]
         end

--- a/lib/lotus/routing/namespace.rb
+++ b/lib/lotus/routing/namespace.rb
@@ -60,19 +60,19 @@ module Lotus
       # @api private
       # @since 0.1.0
       def resource(name, options = {})
-        super name, options.merge(prefix: @name)
+        super name, options.merge(namespace: @name)
       end
 
       # @api private
       # @since 0.1.0
       def resources(name, options = {})
-        super name, options.merge(prefix: @name)
+        super name, options.merge(namespace: @name)
       end
 
       # @api private
       # @since 0.1.0
       def redirect(path, options = {}, &endpoint)
-        super(@name.join(path), options.merge(prefix: @name), &endpoint)
+        super(@name.join(path), options.merge(namespace: @name), &endpoint)
       end
 
       # Supports nested namespaces

--- a/lib/lotus/routing/resource.rb
+++ b/lib/lotus/routing/resource.rb
@@ -62,11 +62,11 @@ module Lotus
       end
 
       def member(&blk)
-        self.class.member.new(@router, @options.merge(prefix: @name), &blk)
+        self.class.member.new(@router, @options.merge(namespace: @name), &blk)
       end
 
       def collection(&blk)
-        self.class.collection.new(@router, @options.merge(prefix: @name), &blk)
+        self.class.collection.new(@router, @options.merge(namespace: @name), &blk)
       end
     end
   end

--- a/lib/lotus/routing/resource/action.rb
+++ b/lib/lotus/routing/resource/action.rb
@@ -85,12 +85,12 @@ module Lotus
           @options[:name]
         end
 
-        # Path prefix
+        # Namespace
         #
         # @api private
-        # @since 0.1.0
-        def prefix
-          @prefix ||= Utils::PathPrefix.new @options[:prefix]
+        # @since x.x.x
+        def namespace
+          @namespace ||= Utils::PathPrefix.new @options[:namespace]
         end
 
         private
@@ -118,7 +118,7 @@ module Lotus
           self.class.verb
         end
 
-        # The prefixed URL relative path
+        # The namespaced URL relative path
         #
         # @example
         #   require 'lotus/router'
@@ -126,7 +126,7 @@ module Lotus
         #   Lotus::Router.new do
         #     resources 'flowers'
         #
-        #     prefix 'animals' do
+        #     namespace 'animals' do
         #       resources 'mammals'
         #     end
         #   end
@@ -137,7 +137,7 @@ module Lotus
         # @api private
         # @since 0.1.0
         def path
-          prefix.join(rest_path)
+          namespace.join(rest_path)
         end
 
         # The URL relative path
@@ -153,7 +153,7 @@ module Lotus
           "/#{ resource_name }"
         end
 
-        # The prefixed name of the action within the whole context of the router.
+        # The namespaced name of the action within the whole context of the router.
         #
         # @example
         #   require 'lotus/router'
@@ -161,7 +161,7 @@ module Lotus
         #   Lotus::Router.new do
         #     resources 'flowers'
         #
-        #     prefix 'animals' do
+        #     namespace 'animals' do
         #       resources 'mammals'
         #     end
         #   end
@@ -172,7 +172,7 @@ module Lotus
         # @api private
         # @since 0.1.0
         def as
-          prefix.relative_join(named_route, '_').to_sym
+          namespace.relative_join(named_route, '_').to_sym
         end
 
         # The name of the action within the whole context of the router.
@@ -247,7 +247,7 @@ module Lotus
 
         private
         def path(path)
-          prefix.join(path)
+          namespace.join(path)
         end
 
         def endpoint(path)

--- a/lib/lotus/routing/resources/action.rb
+++ b/lib/lotus/routing/resources/action.rb
@@ -38,7 +38,7 @@ module Lotus
       class MemberAction < Resource::MemberAction
         private
         def path(path)
-          prefix.join("/:id/#{ path }")
+          namespace.join("/:id/#{ path }")
         end
       end
 


### PR DESCRIPTION
Until now there was two ways to namespace a route:

``` ruby
router = Lotus::Router.new do
  # First way
  get '/login', to: ->(env) { ... }, prefix: '/backend'

  # Second way
  namespace 'dashboard' do
    get '/users', to: ->(env) { ... }
  end
end
```

In the example above, the available routes would be: `/backend/login` and `/dashboard/users`.
Theoretically they are equivalent, but @janko-m [discovered some inconsistencies](https://github.com/lotus/router/pull/24) for the first syntax, which was poorly covered by myself. :sob: This made me to reconsider this feature.

Because I want to simplify both our and developers lives, I want that Lotus has only one way to achieve things. 
I'm suggesting to remove the `:prefix` syntax for the following reasons:
1. It doesn't work.
2. To make this to work would require an effort and requires to add more code to the inner router and resolver.
3. Namespace works properly and keeping this feature allowed to not add code :v: 
4. Simplifies routes definitions. Eg. `Lotus::Router#get` will have **one less** option. Easier code, easier to remember :+1: 
5. Namespace encourages DRY code. Instead of repeating dozen times `:prefix`, developers will have only **one** `namespace` block where to define the nested routes.
6. Code blocks will make easier human recognition in huge routing files. Instead of seeking for dozens `:prefix` options one `namespace` block will help to keep all the routes together.
7. It's not used by developers (see below).

This pull request will remove the code that supports `:prefix` without any deprecation.
This syntax was present in the first release of  `Lotus::Router`, which has been released on Jan 2014. Until now, nobody reported this issue, except for @janko-m who is studying the code of the framework.

We're currently on a version under the 1.0. According to SemVer 2.0 we are allowed to make breaking changes at this point in time.

Ref #24
