### PR TITLE
Remove Mustermann leaf matcher to improve performance

### DIFF
--- a/lib/hanami/middleware/node.rb
+++ b/lib/hanami/middleware/node.rb
@@ -80,7 +80,7 @@ module Hanami
       # @api private
       # @since 2.0.3
       def variable?(segment)
-        Router::ROUTE_VARIABLE_MATCHER.match?(segment)
+        segment.include?(Router::ROUTE_VARIABLE_INDICATOR)
       end
 
       # @api private

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -871,10 +871,7 @@ module Hanami
           raise InvalidRouteDefinitionError.new(http_method, path, "unmatched parenthesis in route")
         end
 
-        [
-          +EMPTY_STRING << match_data.pre_match << match_data[1] << match_data.post_match,
-          +EMPTY_STRING << match_data.pre_match << match_data.post_match
-        ].each do |new_path|
+        optional_routes_from(match_data).each do |new_path|
           if optional?(new_path)
             optional_paths << new_path
           else
@@ -882,6 +879,15 @@ module Hanami
           end
         end
       end
+    end
+
+    # @since 2.2.1
+    # @api private
+    def optional_routes_from(match_data)
+      [
+        -"#{match_data.pre_match}#{match_data[1]}#{match_data.post_match}",
+        -"#{match_data.pre_match}#{match_data.post_match}"
+      ]
     end
 
     # @since 2.0.0

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -751,7 +751,7 @@ module Hanami
 
     # @since 2.0.0
     # @api private
-    ROUTE_VARIABLE_MATCHER = /:/
+    ROUTE_VARIABLE_INDICATOR = ":"
 
     # @since 2.0.0
     # @api private
@@ -890,7 +890,7 @@ module Hanami
     # @since 2.0.0
     # @api private
     def variable?(path)
-      ROUTE_VARIABLE_MATCHER.match?(path)
+      path.include?(ROUTE_VARIABLE_INDICATOR)
     end
 
     # @since 2.2.1

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -753,9 +753,9 @@ module Hanami
     # @api private
     ROUTE_VARIABLE_INDICATOR = ":"
 
-    # @since 2.0.0
+    # @since 2.2.1
     # @api private
-    ROUTE_GLOBBED_MATCHER = /\*/
+    ROUTE_GLOBBED_INDICATOR = "*"
 
     # @since 2.2.1
     # @api private
@@ -902,7 +902,7 @@ module Hanami
     # @since 2.0.0
     # @api private
     def globbed?(path)
-      ROUTE_GLOBBED_MATCHER.match?(path)
+      path.include?(ROUTE_GLOBBED_INDICATOR)
     end
 
     # @since 2.0.0

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -749,7 +749,7 @@ module Hanami
     # @api private
     ROUTE_OPTIONAL_INDICATOR = "("
 
-    # @since 2.0.0
+    # @since 2.2.1
     # @api private
     ROUTE_VARIABLE_INDICATOR = ":"
 

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -869,7 +869,7 @@ module Hanami
         match_data = ROUTE_INNER_PARENTHESES_MATCHER.match(optional_path)
 
         if match_data.nil?
-          raise Hanami::Router::InvalidRouteDefinitionError.new(http_method, path, "unmatched parenthesis in route")
+          raise InvalidRouteDefinitionError.new(http_method, path, "unmatched parenthesis in route")
         end
 
         [

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -863,7 +863,6 @@ module Hanami
     def add_optional_routes(http_method, path, to, constraints, &blk)
       as = nil # avoid creating named routes for all optional permutations
       optional_paths = [path]
-      derived_paths = []
 
       optional_paths.each do |optional_path|
         match_data = ROUTE_INNER_PARENTHESES_MATCHER.match(optional_path)
@@ -879,12 +878,10 @@ module Hanami
           if optional?(new_path)
             optional_paths << new_path
           else
-            derived_paths << new_path
+            add_route(http_method, new_path, to, as, constraints, &blk)
           end
         end
       end
-
-      derived_paths.each { |derived| add_route(http_method, derived, to, as, constraints, &blk) }
     end
 
     # @since 2.0.0

--- a/lib/hanami/router/errors.rb
+++ b/lib/hanami/router/errors.rb
@@ -38,6 +38,21 @@ module Hanami
       end
     end
 
+    # Error raised when a route definition is invalid
+    #
+    # @see Hanami::Router#path
+    # @see Hanami::Router#url
+    #
+    # @since 2.2.1
+    # @api public
+    class InvalidRouteDefinitionError < Error
+      # @since 2.2.1
+      # @api private
+      def initialize(http_method, path, message)
+        super("Invalid route definition '#{http_method.downcase} #{path}': #{message}")
+      end
+    end
+
     # Error raised when variables given for route cannot be expanded into a full path.
     #
     # @see Hanami::Router#path

--- a/lib/hanami/router/leaf.rb
+++ b/lib/hanami/router/leaf.rb
@@ -28,7 +28,11 @@ module Hanami
         return true if @constraints.empty?
 
         @constraints.all? do |key, constraint|
-          match = constraint.match(@params[key.to_s])
+          param_value = @params[key.to_s]
+
+          next true if param_value.nil? # ignore constraints on nonexistent keys
+
+          match = constraint.match(param_value)
 
           match && (match.string == match[0])
         end

--- a/lib/hanami/router/leaf.rb
+++ b/lib/hanami/router/leaf.rb
@@ -14,7 +14,7 @@ module Hanami
       # @api private
       # @since 2.2.0
       def initialize(param_keys, to, constraints)
-        @param_keys = param_keys.map { |key| key[1..] }.freeze
+        @param_keys = param_keys.map { |key| key.delete_prefix(":") }.freeze
         @to = to
         @constraints = constraints
         @params = nil
@@ -23,7 +23,18 @@ module Hanami
       # @api private
       # @since 2.2.0
       def match(param_values)
+        return false if param_values.empty?
+
         @params = @param_keys.zip(param_values).to_h
+
+        return true if @constraints.empty?
+
+        @constraints.all? do |key, constraint|
+
+          match = constraint.match(@params[key.to_s])
+
+          match && (match.string == match[0])
+        end
       end
     end
   end

--- a/lib/hanami/router/leaf.rb
+++ b/lib/hanami/router/leaf.rb
@@ -13,20 +13,17 @@ module Hanami
 
       # @api private
       # @since 2.2.0
-      def initialize(route, to, constraints)
-        @matcher = Mustermann.new(route, type: :rails, version: "5.0", capture: constraints)
+      def initialize(param_keys, to, constraints)
+        @param_keys = param_keys.map { |key| key[1..] }.freeze
         @to = to
+        @constraints = constraints
         @params = nil
       end
 
       # @api private
       # @since 2.2.0
-      def match(path)
-        match = @matcher.match(path)
-
-        @params = match.named_captures if match
-
-        match
+      def match(param_values)
+        @params = @param_keys.zip(param_values).to_h
       end
     end
   end

--- a/lib/hanami/router/leaf.rb
+++ b/lib/hanami/router/leaf.rb
@@ -14,7 +14,7 @@ module Hanami
       # @api private
       # @since 2.2.0
       def initialize(param_keys, to, constraints)
-        @param_keys = param_keys.map { |key| key.delete_prefix(":") }.freeze
+        @param_keys = param_keys.freeze
         @to = to
         @constraints = constraints
         @params = nil

--- a/lib/hanami/router/leaf.rb
+++ b/lib/hanami/router/leaf.rb
@@ -23,8 +23,6 @@ module Hanami
       # @api private
       # @since 2.2.0
       def match(param_values)
-        return false if param_values.empty?
-
         @params = @param_keys.zip(param_values).to_h
 
         return true if @constraints.empty?

--- a/lib/hanami/router/leaf.rb
+++ b/lib/hanami/router/leaf.rb
@@ -28,7 +28,6 @@ module Hanami
         return true if @constraints.empty?
 
         @constraints.all? do |key, constraint|
-
           match = constraint.match(@params[key.to_s])
 
           match && (match.string == match[0])

--- a/lib/hanami/router/leaf.rb
+++ b/lib/hanami/router/leaf.rb
@@ -14,28 +14,19 @@ module Hanami
       # @api private
       # @since 2.2.0
       def initialize(route, to, constraints)
-        @route = route
+        @matcher = Mustermann.new(route, type: :rails, version: "5.0", capture: constraints)
         @to = to
-        @constraints = constraints
         @params = nil
       end
 
       # @api private
       # @since 2.2.0
       def match(path)
-        match = matcher.match(path)
+        match = @matcher.match(path)
 
         @params = match.named_captures if match
 
         match
-      end
-
-      private
-
-      # @api private
-      # @since 2.2.0
-      def matcher
-        @matcher ||= Mustermann.new(@route, type: :rails, version: "5.0", capture: @constraints)
       end
     end
   end

--- a/lib/hanami/router/node.rb
+++ b/lib/hanami/router/node.rb
@@ -23,8 +23,9 @@ module Hanami
 
       # @api private
       # @since 2.0.0
-      def put(segment)
+      def put(segment, param_keys)
         if variable?(segment)
+          param_keys << segment
           @variable ||= self.class.new
         else
           @fixed ||= {}
@@ -34,21 +35,26 @@ module Hanami
 
       # @api private
       # @since 2.0.0
-      def get(segment)
-        @fixed&.fetch(segment, nil) || @variable
+      def get(segment, param_values)
+        fixed = @fixed&.fetch(segment, nil)
+        return fixed if fixed
+
+        param_values << segment
+
+        @variable
       end
 
       # @api private
       # @since 2.0.0
-      def leaf!(route, to, constraints)
+      def leaf!(param_keys, to, constraints)
         @leaves ||= []
-        @leaves << Leaf.new(route, to, constraints)
+        @leaves << Leaf.new(param_keys, to, constraints)
       end
 
       # @api private
       # @since 2.2.0
-      def match(path)
-        @leaves&.find { |leaf| leaf.match(path) }
+      def match(param_values)
+        @leaves&.find { |leaf| leaf.match(param_values) }
       end
 
       private

--- a/lib/hanami/router/node.rb
+++ b/lib/hanami/router/node.rb
@@ -11,10 +11,6 @@ module Hanami
     class Node
       # @api private
       # @since 2.0.0
-      attr_reader :to
-
-      # @api private
-      # @since 2.0.0
       def initialize
         @variable = nil
         @fixed = nil

--- a/lib/hanami/router/node.rb
+++ b/lib/hanami/router/node.rb
@@ -58,7 +58,7 @@ module Hanami
       # @api private
       # @since 2.0.0
       def variable?(segment)
-        Router::ROUTE_VARIABLE_MATCHER.match?(segment)
+        segment.include?(Router::ROUTE_VARIABLE_INDICATOR)
       end
     end
   end

--- a/lib/hanami/router/node.rb
+++ b/lib/hanami/router/node.rb
@@ -21,7 +21,7 @@ module Hanami
       # @since 2.0.0
       def put(segment, param_keys)
         if variable?(segment)
-          param_keys << segment
+          param_keys << segment.delete_prefix(Router::ROUTE_VARIABLE_INDICATOR).freeze
           @variable ||= self.class.new
         else
           @fixed ||= {}

--- a/lib/hanami/router/trie.rb
+++ b/lib/hanami/router/trie.rb
@@ -38,7 +38,7 @@ module Hanami
         node = @root
         param_values = []
 
-        path[1..].split(SEGMENT_SEPARATOR) do |segment|
+        path.slice(1..).split(SEGMENT_SEPARATOR) do |segment|
           node = node.get(segment, param_values)
 
           break if node.nil?

--- a/lib/hanami/router/trie.rb
+++ b/lib/hanami/router/trie.rb
@@ -22,9 +22,8 @@ module Hanami
       # @api private
       # @since 2.0.0
       def add(route, to, constraints)
-        # segments = segments_from(route)
-        param_keys = []
         node = @root
+        param_keys = []
 
         segments_from(route).each do |segment|
           node = node.put(segment, param_keys)
@@ -36,11 +35,14 @@ module Hanami
       # @api private
       # @since 2.0.0
       def find(path)
-        # segments = segments_from(path)
-        param_values = []
         node = @root
+        param_values = []
 
-        return unless segments_from(path).all? { |segment| node = node.get(segment, param_values) }
+        return unless path[1..].split(SEGMENT_SEPARATOR) do |segment|
+          node = node.get(segment, param_values)
+
+          break false if node.nil?
+        end
 
         node.match(param_values)&.then { |found| [found.to, found.params] }
       end

--- a/lib/hanami/router/trie.rb
+++ b/lib/hanami/router/trie.rb
@@ -38,10 +38,10 @@ module Hanami
         node = @root
         param_values = []
 
-        return unless path[1..].split(SEGMENT_SEPARATOR) do |segment|
+        path[1..].split(SEGMENT_SEPARATOR) do |segment|
           node = node.get(segment, param_values)
 
-          break false if node.nil?
+          return if node.nil?
         end
 
         node.match(param_values)&.then { |found| [found.to, found.params] }

--- a/lib/hanami/router/trie.rb
+++ b/lib/hanami/router/trie.rb
@@ -47,7 +47,7 @@ module Hanami
 
       # @api private
       # @since 2.0.0
-      SEGMENT_SEPARATOR = /\//
+      SEGMENT_SEPARATOR = "/"
       private_constant :SEGMENT_SEPARATOR
 
       # @api private

--- a/lib/hanami/router/trie.rb
+++ b/lib/hanami/router/trie.rb
@@ -23,24 +23,26 @@ module Hanami
       # @since 2.0.0
       def add(route, to, constraints)
         segments = segments_from(route)
+        param_keys = []
         node = @root
 
         segments.each do |segment|
-          node = node.put(segment)
+          node = node.put(segment, param_keys)
         end
 
-        node.leaf!(route, to, constraints)
+        node.leaf!(param_keys, to, constraints)
       end
 
       # @api private
       # @since 2.0.0
       def find(path)
         segments = segments_from(path)
+        param_values = []
         node = @root
 
-        return unless segments.all? { |segment| node = node.get(segment) }
+        return unless segments.all? { |segment| node = node.get(segment, param_values) }
 
-        node.match(path)&.then { |found| [found.to, found.params] }
+        node.match(param_values)&.then { |found| [found.to, found.params] }
       end
 
       private

--- a/lib/hanami/router/trie.rb
+++ b/lib/hanami/router/trie.rb
@@ -22,11 +22,11 @@ module Hanami
       # @api private
       # @since 2.0.0
       def add(route, to, constraints)
-        segments = segments_from(route)
+        # segments = segments_from(route)
         param_keys = []
         node = @root
 
-        segments.each do |segment|
+        segments_from(route).each do |segment|
           node = node.put(segment, param_keys)
         end
 
@@ -36,11 +36,11 @@ module Hanami
       # @api private
       # @since 2.0.0
       def find(path)
-        segments = segments_from(path)
+        # segments = segments_from(path)
         param_values = []
         node = @root
 
-        return unless segments.all? { |segment| node = node.get(segment, param_values) }
+        return unless segments_from(path).all? { |segment| node = node.get(segment, param_values) }
 
         node.match(param_values)&.then { |found| [found.to, found.params] }
       end

--- a/lib/hanami/router/trie.rb
+++ b/lib/hanami/router/trie.rb
@@ -41,10 +41,10 @@ module Hanami
         path[1..].split(SEGMENT_SEPARATOR) do |segment|
           node = node.get(segment, param_values)
 
-          return if node.nil?
+          break if node.nil?
         end
 
-        node.match(param_values)&.then { |found| [found.to, found.params] }
+        node&.match(param_values)&.then { |found| [found.to, found.params] }
       end
 
       private

--- a/spec/integration/hanami/router/generation_spec.rb
+++ b/spec/integration/hanami/router/generation_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Hanami::Router do
         end
       end
 
-      xit "generates relative and absolute URLs" do
+      it "generates relative and absolute URLs" do
         runner.run!([
           [:a, "/foo/bar", {var1: "foo", var2: "bar"}],
           [:a, "/foo", {var1: "foo"}]
@@ -177,7 +177,7 @@ RSpec.describe Hanami::Router do
         end
       end
 
-      xit "generates relative and absolute URLs" do
+      it "generates relative and absolute URLs" do
         runner.run!([
           [:a, "/var/fooz/baz", {var1: "var", var2: "fooz", var3: "baz"}],
           [:a, "/var/fooz", {var1: "var", var2: "fooz"}],

--- a/spec/integration/hanami/router/recognition_spec.rb
+++ b/spec/integration/hanami/router/recognition_spec.rb
@@ -305,7 +305,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "fixed with format" do
+    # FIXME: not supported in 2.2.1
+    xdescribe "fixed with format" do
       let(:router) do
         described_class.new do
           get "/test.:format", as: :fixed, to: RecognitionTestCase.endpoint("fixed")
@@ -319,7 +320,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "fixed with optional format" do
+    # FIXME: not supported in 2.2.1
+    xdescribe "fixed with optional format" do
       let(:router) do
         described_class.new do
           get "/test(.:format)", as: :fixed, to: RecognitionTestCase.endpoint("fixed")
@@ -350,7 +352,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "variable with format" do
+    # FIXME: not supported in 2.2.1
+    xdescribe "variable with format" do
       let(:router) do
         described_class.new do
           get "/:test.:format", as: :variable, to: RecognitionTestCase.endpoint("variable")
@@ -364,7 +367,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "variable with optional format" do
+    # FIXME: not supported in 2.2.1
+    xdescribe "variable with optional format" do
       let(:router) do
         described_class.new do
           get "/:test(.:format)", as: :variable, to: RecognitionTestCase.endpoint("variable")
@@ -379,7 +383,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "variable with optional constrainted format" do
+    # FIXME: not supported in 2.2.1
+    xdescribe "variable with optional constrainted format" do
       let(:router) do
         described_class.new do
           get "/:test(.:format)", format: /[^.]+/, as: :variable, to: RecognitionTestCase.endpoint("variable")
@@ -650,7 +655,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "relative fixed with escaped variable" do
+    # FIXME: not supported in 2.2.1
+    xdescribe "relative fixed with escaped variable" do
       let(:router) do
         described_class.new do
           get "test\\:variable", as: :escaped, to: RecognitionTestCase.endpoint("escaped")
@@ -664,7 +670,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "relative fixed with escaped optional variable" do
+    # FIXME: not supported in 2.2.1
+    xdescribe "relative fixed with escaped optional variable" do
       let(:router) do
         described_class.new do
           get "test\\(:variable\\)", as: :escaped, to: RecognitionTestCase.endpoint("escaped")
@@ -706,7 +713,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "variable sourrounded by fixed tokens in the same segment" do
+    # FIXME: not supported in 2.2.1
+    xdescribe "variable sourrounded by fixed tokens in the same segment" do
       let(:router) do
         described_class.new do
           get "/one-:variable-time", as: :variable, to: RecognitionTestCase.endpoint("variable")
@@ -720,7 +728,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "constrainted variable sourrounded by fixed tokens in the same segment" do
+    # FIXME: not supported in 2.2.1
+    xdescribe "constrainted variable sourrounded by fixed tokens in the same segment" do
       let(:router) do
         described_class.new do
           get "/one-:variable-time", as: :variable, variable: /\d+/, to: RecognitionTestCase.endpoint("variable")
@@ -735,7 +744,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "variable sourrounded by fixed token and format in the same segment" do
+    # FIXME: not supported in 2.2.1
+    xdescribe "variable sourrounded by fixed token and format in the same segment" do
       let(:router) do
         described_class.new do
           get "hey.:greed.html", as: :variable, to: RecognitionTestCase.endpoint("variable")
@@ -749,7 +759,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "multiple routes with variables in the same segment" do
+    # FIXME: not supported in 2.2.1
+    xdescribe "multiple routes with variables in the same segment" do
       let(:router) do
         described_class.new do
           get "/:v1-:v2-:v3-:v4-:v5-:v6", as: :var6, to: RecognitionTestCase.endpoint("var6")
@@ -773,7 +784,8 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    context "variable sourrounded by fixed token and format in the same segment" do
+    # FIXME: not supported in 2.2.1
+    xcontext "variable sourrounded by fixed token and format in the same segment" do
       let(:router) do
         described_class.new do
           get "/:common_variable.:matched",   as: :regex,   to: RecognitionTestCase.endpoint("regex"), matched: /\d+/

--- a/spec/unit/hanami/router/leaf_spec.rb
+++ b/spec/unit/hanami/router/leaf_spec.rb
@@ -3,7 +3,7 @@
 require "hanami/router/leaf"
 
 RSpec.describe Hanami::Router::Leaf do
-  let(:subject)     { described_class.new(route, to, constraints) }
+  let(:subject)     { described_class.new([], to, constraints) }
   let(:route)       { "/test/route" }
   let(:to)          { "test proc" }
   let(:constraints) { {} }
@@ -20,7 +20,7 @@ RSpec.describe Hanami::Router::Leaf do
     end
   end
 
-  describe "#match" do
+  xdescribe "#match" do
     context "when path matches route" do
       let(:matching_path) { route }
 
@@ -38,7 +38,7 @@ RSpec.describe Hanami::Router::Leaf do
     end
   end
 
-  describe "#params" do
+  xdescribe "#params" do
     context "without previously calling #match(path)" do
       it "returns nil" do
         params = subject.params

--- a/spec/unit/hanami/router/leaf_spec.rb
+++ b/spec/unit/hanami/router/leaf_spec.rb
@@ -4,7 +4,7 @@ require "hanami/router/leaf"
 
 RSpec.describe Hanami::Router::Leaf do
   let(:subject) { described_class.new(param_keys, to, constraints) }
-  let(:to)          { "test proc" }
+  let(:to) { "test proc" }
 
   describe "#initialize" do
     let(:param_keys)  { [] }
@@ -30,11 +30,11 @@ RSpec.describe Hanami::Router::Leaf do
   end
 
   describe "#match" do
-      let(:param_keys)    { [":variable"] }
-      let(:param_values)  { ["value"] }
+    let(:param_keys) { [":variable"] }
+    let(:param_values) { ["value"] }
 
     context "with no constraints" do
-      let(:constraints)   { {} }
+      let(:constraints) { {} }
 
       it "returns true" do
         result = subject.match(param_values)

--- a/spec/unit/hanami/router/leaf_spec.rb
+++ b/spec/unit/hanami/router/leaf_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hanami::Router::Leaf do
   end
 
   describe "#match" do
-    let(:param_keys) { [":variable"] }
+    let(:param_keys) { ["variable"] }
     let(:param_values) { ["value"] }
 
     context "with no constraints" do

--- a/spec/unit/hanami/router/node_spec.rb
+++ b/spec/unit/hanami/router/node_spec.rb
@@ -27,11 +27,12 @@ RSpec.describe Hanami::Router::Node do
     context "when segment is variable" do
       it "updates param_keys" do
         variable_segment = ":foo"
+        key_for_variable_segment = "foo"
         param_keys = []
 
         subject.put(variable_segment, param_keys)
 
-        expect(param_keys).to include(":foo")
+        expect(param_keys).to include(key_for_variable_segment)
       end
     end
   end

--- a/spec/unit/hanami/router/node_spec.rb
+++ b/spec/unit/hanami/router/node_spec.rb
@@ -6,7 +6,33 @@ require "hanami/router/leaf"
 RSpec.describe Hanami::Router::Node do
   describe "#initialize" do
     it "returns a #{described_class} instance" do
-      expect(subject).to be_kind_of(described_class)
+      result = subject
+
+      expect(result).to be_kind_of(described_class)
+    end
+  end
+
+  describe "#put" do
+    context "when segment is fixed" do
+      it "does not update param_keys" do
+        segment = "foo"
+        param_keys = []
+
+        subject.put(segment, param_keys)
+
+        expect(param_keys).to be_empty
+      end
+    end
+
+    context "when segment is variable" do
+      it "updates param_keys" do
+        variable_segment = ":foo"
+        param_keys = []
+
+        subject.put(variable_segment, param_keys)
+
+        expect(param_keys).to include(":foo")
+      end
     end
   end
 
@@ -20,19 +46,51 @@ RSpec.describe Hanami::Router::Node do
 
           subject.put(segment, param_keys)
 
-          expect(subject.get(segment, param_values)).to be_kind_of(described_class)
+          result = subject.get(segment, param_values)
+
+          expect(result).to be_kind_of(described_class)
+        end
+
+        it "does not update param_values" do
+          segment = "foo"
+          param_keys = []
+          param_values = []
+
+          subject.put(segment, param_keys)
+          subject.get(segment, param_values)
+
+          result = param_values
+
+          expect(result).to be_empty
         end
       end
 
       context "and segment is variable" do
         it "returns a node" do
-          dynamic_segment = ":foo"
+          variable_segment = ":foo"
           param_keys = []
+          path_segment = "bar"
           param_values = []
 
-          subject.put(dynamic_segment, param_keys)
+          subject.put(variable_segment, param_keys)
 
-          expect(subject.get("bar", param_values)).to be_kind_of(described_class)
+          result = subject.get(path_segment, param_values)
+
+          expect(result).to be_kind_of(described_class)
+        end
+
+        it "update param_values" do
+          variable_segment = ":foo"
+          param_keys = []
+          path_segment = "bar"
+          param_values = []
+
+          subject.put(variable_segment, param_keys)
+          subject.get(path_segment, param_values)
+
+          result = param_values
+
+          expect(result).to include("bar")
         end
       end
     end
@@ -41,80 +99,65 @@ RSpec.describe Hanami::Router::Node do
       it "returns nil" do
         segment = "foo"
         param_keys = []
+        path_segment = "bar"
         param_values = []
 
         subject.put(segment, param_keys)
 
-        expect(subject.get("bar", param_values)).to be_nil
+        result = subject.get(path_segment, param_values)
+
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#leaf!" do
+    context "when called" do
+      it "returns a Leaf object" do
+        segment = "foo"
+        to = "target action"
+        constraints = {}
+        param_keys = []
+        param_values = []
+
+        subject.put(segment, param_keys).leaf!(param_keys, to, constraints)
+
+        result = subject.get(segment, param_values).match(param_values)
+
+        expect(result).to be_kind_of(Hanami::Router::Leaf)
       end
     end
   end
 
   describe "#match" do
-    context "when segment is fixed" do
-      context "and match not found" do
-        it "returns nil" do
-          segment = "foo"
-          route = "/foo"
-          to = double("to")
-          constraints = {}
-          path = "/bar"
-          param_keys = []
-          param_values = []
+    context "when @leaves collection is empty" do
+      it "returns nil" do
+        segment = "foo"
+        param_keys = []
+        param_values = []
 
-          subject.put(segment, param_keys).leaf!(param_keys, to, constraints)
+        subject.put(segment, param_keys)
 
-          expect(subject.get(segment, param_values).match(param_values)).to be_nil
-        end
-      end
+        result = subject.get(segment, param_values).match(param_values)
 
-      context "and match is found" do
-        it "returns a Leaf object" do
-          segment = "foo"
-          route = "/foo"
-          to = double("to")
-          constraints = {}
-          param_keys = []
-          param_values = []
-
-          subject.put(segment, param_keys).leaf!(param_keys, to, constraints)
-
-          expect(subject.get(segment, param_values).match(param_values)).to be_kind_of(Hanami::Router::Leaf)
-        end
+        expect(result).to be_nil
       end
     end
 
-    context "when segment is variable" do
-      context "and match not found" do
-        it "returns nil" do
-          segment = ":foo"
-          route = "/:foo"
-          to = double("to")
-          constraints = {foo: :digit}
-          path = "/bar"
-          param_keys = []
-          param_values = []
+    context "when @leaves collection contains a match" do
+      it "returns the matching leaf" do
+        segment = "foo"
+        to = "target action"
+        constraints = {}
+        param_keys = []
+        param_values = []
 
-          subject.put(segment, param_keys).leaf!(param_keys, to, constraints)
+        subject.put(segment, param_keys).leaf!(param_keys, to, constraints)
+        leaf = subject.get(segment, param_values).match(param_values)
 
-          expect(subject.get(segment, param_values).match(param_values)).to be_nil
-        end
-      end
+        result = leaf.to
 
-      context "and match found" do
-        it "returns Leaf object" do
-          segment = ":foo"
-          route = "/:foo"
-          to = double("to")
-          constraints = {foo: :digit}
-          path = "/123"
-          param_keys = []
-          param_values = []
-
-          subject.put(segment, param_keys).leaf!(param_keys, to, constraints)
-
-          expect(subject.get(segment, param_values).match(param_values)).to be_kind_of(Hanami::Router::Leaf)
-        end
+        expect(result).to be("target action")
       end
     end
   end

--- a/spec/unit/hanami/router/node_spec.rb
+++ b/spec/unit/hanami/router/node_spec.rb
@@ -15,18 +15,24 @@ RSpec.describe Hanami::Router::Node do
       context "and segment is fixed" do
         it "returns a node" do
           segment = "foo"
-          subject.put(segment)
+          param_keys = []
+          param_values = []
 
-          expect(subject.get(segment)).to be_kind_of(described_class)
+          subject.put(segment, param_keys)
+
+          expect(subject.get(segment, param_values)).to be_kind_of(described_class)
         end
       end
 
       context "and segment is variable" do
         it "returns a node" do
           dynamic_segment = ":foo"
-          subject.put(dynamic_segment)
+          param_keys = []
+          param_values = []
 
-          expect(subject.get("bar")).to be_kind_of(described_class)
+          subject.put(dynamic_segment, param_keys)
+
+          expect(subject.get("bar", param_values)).to be_kind_of(described_class)
         end
       end
     end
@@ -34,9 +40,12 @@ RSpec.describe Hanami::Router::Node do
     context "when segment is not found" do
       it "returns nil" do
         segment = "foo"
-        subject.put(segment)
+        param_keys = []
+        param_values = []
 
-        expect(subject.get("bar")).to be_nil
+        subject.put(segment, param_keys)
+
+        expect(subject.get("bar", param_values)).to be_nil
       end
     end
   end
@@ -50,9 +59,12 @@ RSpec.describe Hanami::Router::Node do
           to = double("to")
           constraints = {}
           path = "/bar"
-          subject.put(segment).leaf!(route, to, constraints)
+          param_keys = []
+          param_values = []
 
-          expect(subject.get(segment).match(path)).to be_nil
+          subject.put(segment, param_keys).leaf!(param_keys, to, constraints)
+
+          expect(subject.get(segment, param_values).match(param_values)).to be_nil
         end
       end
 
@@ -62,9 +74,12 @@ RSpec.describe Hanami::Router::Node do
           route = "/foo"
           to = double("to")
           constraints = {}
-          subject.put(segment).leaf!(route, to, constraints)
+          param_keys = []
+          param_values = []
 
-          expect(subject.get(segment).match(route)).to be_kind_of(Hanami::Router::Leaf)
+          subject.put(segment, param_keys).leaf!(param_keys, to, constraints)
+
+          expect(subject.get(segment, param_values).match(param_values)).to be_kind_of(Hanami::Router::Leaf)
         end
       end
     end
@@ -77,9 +92,12 @@ RSpec.describe Hanami::Router::Node do
           to = double("to")
           constraints = {foo: :digit}
           path = "/bar"
-          subject.put(segment).leaf!(route, to, constraints)
+          param_keys = []
+          param_values = []
 
-          expect(subject.get(segment).match(path)).to be_nil
+          subject.put(segment, param_keys).leaf!(param_keys, to, constraints)
+
+          expect(subject.get(segment, param_values).match(param_values)).to be_nil
         end
       end
 
@@ -90,9 +108,12 @@ RSpec.describe Hanami::Router::Node do
           to = double("to")
           constraints = {foo: :digit}
           path = "/123"
-          subject.put(segment).leaf!(route, to, constraints)
+          param_keys = []
+          param_values = []
 
-          expect(subject.get(segment).match(path)).to be_kind_of(Hanami::Router::Leaf)
+          subject.put(segment, param_keys).leaf!(param_keys, to, constraints)
+
+          expect(subject.get(segment, param_values).match(param_values)).to be_kind_of(Hanami::Router::Leaf)
         end
       end
     end

--- a/spec/unit/hanami/router/trie_spec.rb
+++ b/spec/unit/hanami/router/trie_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Hanami::Router::Trie do
     let(:foo) { double("foo") }
     let(:bar) { double("bar") }
     let(:baz) { double("baz") }
-    let(:foo_constraints) { {foo: :digit} }
+    let(:foo_constraints) { {foo: /\d+/} }
     let(:empty_constraints) { {} }
 
     it "matches path with variable segment and matching constraints" do


### PR DESCRIPTION
# Router Improvement

This will be a long-running, exploratory spike intended to remove the router's dependency on Mustermann and improve performance overall. Router performance is defined by two metrics: start up time and requests-per-second, both measured using the [r10k](https://github.com/jeremyevans/r10k) benchmarking tool. I feel that this tool, r10k, is problematic for a number of reasons, but it is readily available and offers a general sense of performance changes as the spike progresses.

I invite any and all comments as this goes along. I am tagging the following contributors to request their input:

@kyleplump @cllns @timriley 

## Goals

[Mustermann](https://rubydoc.info/gems/mustermann/frames) is a powerful string matching library that offers many features, most of which our router does *not* use. In fact, some of the work done by Mustermann is duplicated by the work the current router does in splitting route and path strings into segments in order to utilize trie data structures. Since Mustermann pattern objects are complex and resource intensive to create, eliminating this dependency should improve router startup time, performance in production, and reduced memory usage. I hope. :roll_eyes: 

I believe that further improvements may be possible on these same metrics through a more general refactor of the router's operation. I would like to explore these ideas as well.

---

## Checklists

Following are a series of checklists to guide progress on this spike. They should be considered "living lists" that will change during the process. Please feel free to edit the lists (or suggest edits) if they are not complete or detailed enough.

### Current features

The [Hanami Routing guide](https://guides.hanamirb.org/v2.2/routing/overview/#constraints) commits to supporting the following features (checked items have been re-implemented so far without Mustermann):

- [x] Match segment-length dynamic variables without constraints.
- [x] Constraints on dynamic variables (expressed as regular expressions in the route definition).
- [x] Optional route clauses, like `get "/books(/:id)"`.
- [x] Globbing & Catch all routes - this is unchanged from earlier versions (2.0 - 2.1). It is implemented through special handling in the router (uses Mustermann, but separate from routes stored in tries).

### Features *NOT* implemented

These are undocumented--so far as the Hanami guides and the router README are concerned--features of the 2.1 and 2.2 routers that are powered by Mustermann and technically possible, but possibly can't be duplicated with 1-1 parity using my current approach. 

- [ ] Constraints using POSIX-like notation.
- [ ] Escaped characters in route definition, like `"/test\\:variable"`
- [ ] Sub-segment-length dynamic variables, like `"/test.:format"`
- [ ] Sub-segment-length dynamic variables that are *also* delimited by `.` character, like `"/hey.:greed.html"` (captures `:greed`).

### Edge cases

I am aware of the following edge cases that aren't specifically covered in the guides, but merit discussion. It would be good to establish explicit rules for them.

- [ ] Trailing slashes
  - the 2.1 router did not handle trailing slashes correctly, leading to ambiguous results. 
  - the 2.2 router does handle trailing slashes correctly and treats `/books/:id` and `books/:id/` as distinct, matchable routes (because it uses Mustermann to match the complete, original route definition).
  - the 2.2c+ routers developed during this spike no longer handle trialing slashes correctly. This is because we use `String#split` on path strings, which ignores the final character if it is the `#split` parameter.

### Stretch goals

I believe these goals are possible with my current  approach. I will implement them if there is consensus on their value.

- [ ] Conversion of URI-encoded values in path strings (not mentioned in the routes, but a basic necessity).
- [ ] User defined constraint objects (must respond to `#match?`, for example, and receive a string argument).

---

## Starting Point

The current 2.2 router introduced a performance regression compared to 2.1 (see #278 ). This commit (2.2a) corrects the core issue causing that regression, as identified and fixed by @kyleplump (see #279) and restores near parity to 2.1's speed, while increasing start up time (primarily due to Mustermann object creation during start up). This is our starting point, as shown in the following graphs.

Benchmark machine: AMD Ryzen 7 laptop with 24GB of RAM and no attempt to restrict background processes (in other words, YMMV).

Commit label: 2.2a
Test status: 544 examples, 0 failures, 37 pending

<details>
<summary>

###### expand to see graphs

</summary>

![graph comparing 2.1 with 2.2a in requests per second. 2.2a is slightly slower as the number of defined routes increases](https://github.com/user-attachments/assets/beb55157-5598-455a-a3dd-4508a5e60d5b)

![graph comparing 2.1 with 2.2a in start up time. 2.2a is much slower to start up as defined routes pass 1000](https://github.com/user-attachments/assets/08131ebe-fb70-46c5-844c-1dc374c46e08)

![graph comparing 2.1 with 2.2a in memory usage. 2.2a uses increasingly higher memory in comparison as the number of defined routes increases.](https://github.com/user-attachments/assets/4af6635f-22cf-45cc-96a5-14005d1a68ca)

</details>