### PR TITLE
Improve route naming flexibility

### DIFF
--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -929,9 +929,9 @@ module Hanami
       name = Array(name)
 
       if name.size < 2
-        [nil, name.first.to_s]
+        [nil, name.first&.to_s]
       else
-        [name.first.to_s, name[1..].join("_")]
+        [name.first&.to_s, name[1..].join("_")]
       end
     end
 

--- a/spec/integration/hanami/router/route_names_spec.rb
+++ b/spec/integration/hanami/router/route_names_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe Hanami::Router, "route names" do
 
           get "/dogs", to: -> {}, as: [:dogs]
           get "/dogs/new", to: -> {}, as: [:new, :very, :good, :boy]
+
+          get "/cows", to: -> {}, as: [nil, :cows]
         end
       end
     end
@@ -43,5 +45,6 @@ RSpec.describe Hanami::Router, "route names" do
     expect(router.path("new_backend_secret_cat")).to eq "/backend/admin/cats/new"
     expect(router.path("backend_secret_dogs")).to eq "/backend/admin/dogs"
     expect(router.path("new_backend_secret_very_good_boy")).to eq "/backend/admin/dogs/new"
+    expect(router.path("backend_secret_cows")).to eq "/backend/admin/cows"
   end
 end


### PR DESCRIPTION
Make route naming more flexible.

- Provide `as:` to `scope` to customise its route name prefix. This previously used the URL portion of the scope as the prefix in all cases. This is not good for complex scopes, e.g. `"cafes/:cafe_id"`.
- When naming routes with `as:`, provide a `["prefix", "suffix"]` array to allow the prefix to be placed at the very beginning of the generated route name. This is a new capability, and it's relevant when using routes within scopes. For those routes, their names are always prefixed by the names of their scopes, which means it's never been possible to put some portion of the route name at the very beginning of the string. It's important to be able to do this for creating route names with a leading verb, like "new_deeply_nested_thing". To do this, you can now create a route with `as: [:new, :thing]`. See the tests in this PR for examples.

I chose the `["prefix", "suffix"]` array syntax because it is concise and it still reads quite well when given a pair of names.

Aside from this being useful in its own right, this also supports the `resources` routing helpers being added in https://github.com/hanami/hanami/pull/1542.