### PR TITLE
Refer to media types in body parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,15 +22,21 @@ Rack compatible HTTP router for Ruby
 - As part of Rack v2/v3 compatibility, improve coordination between `Hanami::Middleware::BodyParser` and `Hanami::Router` regarding access of the request body. (@timriley in #287)
 
   `BodyParser` will now make `env["rack.input"]` rewindable, and rewind the body after accessing it, ensuring downstream users can still read `"rack.input"` if needed. `Router` will only attempt to make `"rack.input"` rewindable if it hasn’t already been made so.
-- Allow `Hanami::Middleware::BodyParser` to be initialized with a single body parser. (@timriley in #288)
+- Change `Hanami::Middleware::BodyParser::Parser` to refer to `media_types` instead of `mime_types`. (@timriley in #289)
+
+  A body parser subclass should now look like this:
 
   ```ruby
-  class MyCustomParser < Hanami::Middleware::BodyParser::Parser
-    def self.mime_types = ["application/custom"]
-    def parse(_body) = "..."
+  class CustomParser < Hanami::Middleware::BodyParser::Parser
+    def self.media_types = ["application/custom"]
+    def parse(body)
+      body # Your parsing logic here
+    end
   end
+  ```
+- Allow `Hanami::Middleware::BodyParser` to be initialized with a single body parser, instead of requiring an array. (@timriley in #288)
 
-  # Previously, this required [MyCustomParser]
+  ```ruby
   Hanami::Middleware::BodyParser.new(app, MyCustomParser)
   ```
 

--- a/lib/hanami/middleware/body_parser/class_interface.rb
+++ b/lib/hanami/middleware/body_parser/class_interface.rb
@@ -63,12 +63,12 @@ module Hanami
                 build_parsers([key => [value]], memo)
               end
             else
-              name, *mime_types = Array(*spec).flatten(0)
+              name, *media_types = Array(*spec).flatten(0)
 
-              parser = build(name, mime_types: mime_types.flatten)
+              parser = build(name, media_types: media_types.flatten)
 
-              parser.mime_types.each do |mime|
-                memo[mime] = parser
+              parser.media_types.each do |type|
+                memo[type] = parser
               end
             end
           end
@@ -78,7 +78,7 @@ module Hanami
 
         # @api private
         # @since 1.3.0
-        PARSER_METHODS = %i[mime_types parse].freeze
+        PARSER_METHODS = %i[media_types parse].freeze
 
         # @api private
         # @since 2.0.0

--- a/lib/hanami/middleware/body_parser/form_parser.rb
+++ b/lib/hanami/middleware/body_parser/form_parser.rb
@@ -9,17 +9,12 @@ module Hanami
       # @since 2.0.1
       # @api private
       class FormParser < Parser
-        # @since 2.0.1
         # @api private
-        MIME_TYPES = [
-          "multipart/form-data"
-        ].freeze
+        MEDIA_TYPES = ["multipart/form-data"].freeze
 
         # @since 2.0.1
         # @api private
-        def self.mime_types
-          MIME_TYPES
-        end
+        def self.media_types = MEDIA_TYPES
 
         # Parse a multipart body payload (form file uploading)
         #

--- a/lib/hanami/middleware/body_parser/json_parser.rb
+++ b/lib/hanami/middleware/body_parser/json_parser.rb
@@ -9,11 +9,11 @@ module Hanami
       # @since 1.3.0
       # @api private
       class JsonParser < Parser
-        # @since 1.3.0
         # @api private
-        def self.mime_types
-          ["application/json", "application/vnd.api+json"]
-        end
+        MEDIA_TYPES = ["application/json", "application/vnd.api+json"].freeze
+
+        # @api private
+        def self.media_types = MEDIA_TYPES
 
         # Parse a json string
         #

--- a/lib/hanami/middleware/body_parser/parser.rb
+++ b/lib/hanami/middleware/body_parser/parser.rb
@@ -7,11 +7,14 @@ module Hanami
       #
       # @since 2.0.0
       class Parser
-        DEFAULT_MIME_TYPES = [].freeze
+        class << self
+          def media_types = []
+          alias_method :mime_types, :media_types
+        end
 
-        # Return supported mime types
+        # Return supported media types
         #
-        # @return [Array<String>] supported MIME types
+        # @return [Array<String>] supported media types
         #
         # @abstract
         # @since 2.0.0
@@ -20,15 +23,16 @@ module Hanami
         #   require "hanami/middleware/body_parser"
         #
         #   class XMLParser < Hanami::Middleware::BodyParser::Parser
-        #     def self.mime_types
+        #     def self.media_types
         #       ["application/xml", "text/xml"]
         #     end
         #   end
-        attr_reader :mime_types
+        attr_reader :media_types
+        alias_method :mime_types, :media_types
 
         # @api private
-        def initialize(mime_types: DEFAULT_MIME_TYPES)
-          @mime_types = self.class.mime_types + mime_types
+        def initialize(media_types: [])
+          @media_types = self.class.media_types + media_types
         end
 
         # Parse raw HTTP request body

--- a/spec/integration/hanami/middleware/body_parser_spec.rb
+++ b/spec/integration/hanami/middleware/body_parser_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Hanami::Middleware::BodyParser do
         .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)
     end
 
-    it "accepts a parser name with additional mime-type" do
+    it "accepts a parser name with additional media type" do
       body_parser = Hanami::Middleware::BodyParser.new(app, [json: "application/json+scim"])
 
       expect(body_parser.instance_variable_get("@parsers")["application/json+scim"])
         .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)
     end
 
-    it "accepts a parser name with additional mime-types" do
+    it "accepts a parser name with additional media types" do
       body_parser = Hanami::Middleware::BodyParser.new(
         app, [json: ["application/json+scim", "application/json+foo"]]
       )
@@ -30,11 +30,9 @@ RSpec.describe Hanami::Middleware::BodyParser do
         .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)
     end
 
-    it "accepts multiple parser names with additional mime-type" do
+    it "accepts multiple parser names with additional media type" do
       class Hanami::Middleware::BodyParser::XmlParser < Hanami::Middleware::BodyParser::Parser
-        def self.mime_types
-          ["application/xml"]
-        end
+        def self.media_types = ["application/xml"]
       end
 
       body_parser = Hanami::Middleware::BodyParser.new(
@@ -54,9 +52,7 @@ RSpec.describe Hanami::Middleware::BodyParser do
 
     it "accepts multiple parser class ids" do
       class Hanami::Middleware::BodyParser::XmlParser < Hanami::Middleware::BodyParser::Parser
-        def self.mime_types
-          ["application/xml"]
-        end
+        def self.media_types = ["application/xml"]
       end
 
       body_parser = Hanami::Middleware::BodyParser.new(app, [:json, :xml])
@@ -80,7 +76,7 @@ RSpec.describe Hanami::Middleware::BodyParser do
 
     it "accepts a custom parser class" do
       custom_parser_class = Class.new(Hanami::Middleware::BodyParser::Parser) do
-        def self.mime_types = ["application/custom"]
+        def self.media_types = ["application/custom"]
         def parse(_body) = "custom"
       end
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -534,9 +534,7 @@ module Keys
 end # Keyboards
 
 class XMLBodyParser < Hanami::Middleware::BodyParser::Parser
-  def self.mime_types
-    ["application/xml", "text/xml"]
-  end
+  def self.media_types = ["application/xml", "text/xml"]
 
   def parse(body, *)
     result = {}

--- a/spec/unit/hanami/middleware/body_parser_spec.rb
+++ b/spec/unit/hanami/middleware/body_parser_spec.rb
@@ -6,14 +6,9 @@ require "hanami/middleware/body_parser/json_parser"
 RSpec.describe Hanami::Middleware::BodyParser do
   describe ".build" do
     let(:parser_class) do
-      Class.new do
-        def mime_types
-          ["text"]
-        end
-
-        def parse(body)
-          body
-        end
+      Class.new(Hanami::Middleware::BodyParser::Parser) do
+        def self.media_types = ["text"]
+        def parse(body) = body
       end
     end
 


### PR DESCRIPTION
Replace the old “MIME types” language (which we’ve also moved away from in hanami-controller) with the more modern “media types” terminology.