### PR TITLE
Improve routes command handling of long routes

### DIFF
--- a/lib/hanami/router/formatter/human_friendly.rb
+++ b/lib/hanami/router/formatter/human_friendly.rb
@@ -35,21 +35,49 @@ module Hanami
 
         # @api private
         # @since 2.0.0
+        COLUMN_SPACING = 5
+        private_constant :COLUMN_SPACING
+
+        # @api private
+        # @since 2.0.0
         def call(routes)
-          routes.filter_map(&method(:format_route_unless_head)).join(NEW_LINE)
+          filtered_routes = routes.reject(&:head?)
+          return "" if filtered_routes.empty?
+
+          column_widths = calculate_column_widths(filtered_routes)
+          filtered_routes.map { |route| format_route(route, column_widths) }.join(NEW_LINE)
         end
 
         private
 
-        def format_route_unless_head(route)
-          !route.head? &&
-            [
-              route.http_method.to_s.ljust(SMALL_STRING_JUSTIFY_AMOUNT),
-              route.path.ljust(LARGE_STRING_JUSTIFY_AMOUNT),
-              route.inspect_to.ljust(LARGE_STRING_JUSTIFY_AMOUNT),
-              route.as? ? "as #{route.inspect_as}".ljust(MEDIUM_STRING_JUSTIFY_AMOUNT) : "",
-              route.constraints? ? "(#{route.inspect_constraints})".ljust(EXTRA_LARGE_STRING_JUSTIFY_AMOUNT) : ""
-            ].join
+        def calculate_column_widths(routes)
+          path_width = LARGE_STRING_JUSTIFY_AMOUNT
+          inspect_to_width = LARGE_STRING_JUSTIFY_AMOUNT
+          as_width = MEDIUM_STRING_JUSTIFY_AMOUNT
+          constraints_width = EXTRA_LARGE_STRING_JUSTIFY_AMOUNT
+
+          routes.each do |route|
+            path_width = [path_width, route.path.length].max
+            inspect_to_width = [inspect_to_width, route.inspect_to.length].max
+            as_width = [as_width, route.as? ? "as #{route.inspect_as}".length : 0].max
+            constraints_width = [constraints_width,
+                                 route.constraints? ? "(#{route.inspect_constraints})".length : 0].max
+          end
+
+          # Include spacing in the widths
+          [path_width + COLUMN_SPACING, inspect_to_width + COLUMN_SPACING, as_width + COLUMN_SPACING, constraints_width]
+        end
+
+        def format_route(route, column_widths)
+          path_width, inspect_to_width, as_width, constraints_width = column_widths
+
+          [
+            route.http_method.to_s.ljust(SMALL_STRING_JUSTIFY_AMOUNT),
+            route.path.ljust(path_width),
+            route.inspect_to.ljust(inspect_to_width),
+            route.as? ? "as #{route.inspect_as}".ljust(as_width) : "",
+            route.constraints? ? "(#{route.inspect_constraints})".ljust(constraints_width) : ""
+          ].join
         end
       end
     end

--- a/spec/integration/hanami/router/inspection_spec.rb
+++ b/spec/integration/hanami/router/inspection_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "Router: inspection" do
 
   it "inspects the routes" do
     expected = [
-      "GET     /                             (proc)                        as :root",
-      "GET     /api                          (proc)                        as :api_root"
+      "GET     /                                  (proc)                             as :root            ",
+      "GET     /api                               (proc)                             as :api_root        "
     ]
 
     actual = inspector.call

--- a/spec/unit/hanami/router/formatter/human_friendly_spec.rb
+++ b/spec/unit/hanami/router/formatter/human_friendly_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hanami::Router::Formatter::HumanFriendly do
           Hanami::Router::Route.new(http_method: "GET", path: "/resources/:id", to: "resource#show", as: :resource, constraints: {id: /\d+/})
         ]
 
-        expected = "GET     /resources/:id                resource#show                 as :resource        (id: /\\d+/)                             "
+        expected = "GET     /resources/:id                     resource#show                      as :resource             (id: /\\d+/)                             "
         expect(subject.call(routes)).to eq(expected)
       end
 


### PR DESCRIPTION
I am porting a Rails app to Hanami that has some deeep routes with long controller names. This is a sample of the output from the `hanami routes` command. The columns of the output is being squashed together.
```
GET     /admin/practitioners/:practitioner_id/appointment_types/:id/editappointment_types.edit        as :edit_admin_practitioner_appointment_type
PATCH   /admin/practitioners/:practitioner_id/appointment_types/:idappointment_types.update      as :admin_practitioner_appointment_type
DELETE  /admin/practitioners/:practitioner_id/appointment_types/:idappointment_types.destroy     as :admin_practitioner_appointment_type
POST    /admin/practitioners/:practitioner_id/schedulesschedules.create              as :admin_practitioner_schedules
PATCH   /admin/practitioners/:practitioner_id/schedules/:idschedules.update              as :admin_practitioner_schedule
```

This is after this fix. The column alignment is being maintained.
```
GET     /admin/practitioners/:practitioner_id/appointment_types/:id/edit                             appointment_types.edit                 as :edit_admin_practitioner_appointment_type
PATCH   /admin/practitioners/:practitioner_id/appointment_types/:id                                  appointment_types.update               as :admin_practitioner_appointment_type
DELETE  /admin/practitioners/:practitioner_id/appointment_types/:id                                  appointment_types.destroy              as :admin_practitioner_appointment_type
POST    /admin/practitioners/:practitioner_id/schedules                                              schedules.create                       as :admin_practitioner_schedules
PATCH   /admin/practitioners/:practitioner_id/schedules/:id                                          schedules.update                       as :admin_practitioner_schedule
```

The code ieterates the routes twice. Once to find the max column width and second to print out the routes. This might be slow for an application with a lot of routes.
The new code also maintains a 5 character spacing between columns.