### PR TITLE
Upgrade mustermann to 3.1 and remove mustermann-contrib

### DIFF
--- a/hanami-router.gemspec
+++ b/hanami-router.gemspec
@@ -32,8 +32,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.2"
 
   spec.add_runtime_dependency "rack", ">= 2.2.16"
-  spec.add_runtime_dependency "mustermann", "~> 3.0"
-  spec.add_runtime_dependency "mustermann-contrib", "~> 3.0"
+  spec.add_runtime_dependency "mustermann", "~> 3.1"
   spec.add_runtime_dependency "csv", "~> 3.3"
 end
-

--- a/repo-sync.yml
+++ b/repo-sync.yml
@@ -13,6 +13,5 @@ gemspec:
   homepage: "https://hanamirb.org"
   runtime_dependencies:
     - ["rack", ">= 2.2.16"]
-    - ["mustermann", "~> 3.0"]
-    - ["mustermann-contrib", "~> 3.0"]
+    - ["mustermann", "~> 3.1"]
     - ["csv", "~> 3.3"]


### PR DESCRIPTION
Mustermann 3.1 now includes Rails-style route patterns. This change also removes the transitive dependencies on [hansi](https://rubygems.org/gems/hansi) and [ruby2_keywords](https://rubygems.org/gems/ruby2_keywords).