### PR TITLE
Refactor `recognize` to take params as kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,34 @@ Rack compatible HTTP router for Ruby.
 
 ### Changed
 
+- **BREAKING**: `Router#recognize` signature changed from `(env, params = {}, options = {})` to `(target, params: {}, **options)`. Rack env options (like `method:`) are now kwargs, and named-route variables must be passed under the `params:` keyword.
+
+    Migration:
+
+    ```ruby
+    # Before
+    router.recognize(:book, id: 23)
+    router.recognize("/books/23", {}, method: :post)
+
+    # After
+    router.recognize(:book, params: {id: 23})
+    router.recognize("/books/23", method: :post)
+    ```
+
+    String-keyed Rack env entries (e.g. `"HTTP_AUTHORIZATION"`) can no longer be passed through `recognize` directly, since kwargs only accept symbol keys. Build the env explicitly and pass it as the first argument instead:
+
+    ```ruby
+    env = Rack::MockRequest.env_for("/books/23", "HTTP_AUTHORIZATION" => "token")
+    router.recognize(env)
+    ```
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- `Router#recognize` now correctly honours the `method:` kwarg when called without an explicit `params` hash. Previously `router.recognize("/images", method: "POST")` silently fell back to GET because `method:` was absorbed into the positional `params` argument. (#271)
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -324,13 +324,13 @@ route.endpoint  # => "books.show"
 route.params    # => {:id=>"23"}
 route.routable? # => true
 
-route = router.recognize(:book, id: 23)
+route = router.recognize(:book, params: {id: 23})
 route.verb      # "GET"
 route.endpoint  # => "books.show"
 route.params    # => {:id=>"23"}
 route.routable? # => true
 
-route = router.recognize("/books/23", {}, method: :post)
+route = router.recognize("/books/23", method: :post)
 route.verb      # "POST"
 route.routable? # => false
 ```

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -522,21 +522,26 @@ module Hanami
       url_helpers.url(name, variables)
     end
 
-    # Recognize the given env, path, or name and return a route for testing
+    # Recognize the given target and return a route for testing inspection.
+    #
+    # The target may be a path, a named route, or a Rack env. If the route
+    # cannot be recognized, an unroutable object is still returned for
     # inspection.
     #
-    # If the route cannot be recognized, it still returns an object for testing
-    # inspection.
-    #
-    # @param env [Hash, String, Symbol] Rack env, path or route name
-    # @param options [Hash] a set of options for Rack env or route params
-    # @param params [Hash] a set of params
+    # @param target [String, Symbol, Hash] target (Rack env hash, path, or route name)
+    # @param params [Hash] named-route variables used to build the path
+    # @param options [Hash] Rack env options (e.g. `method:`) forwarded to
+    #   `Rack::MockRequest.env_for`, unless `target` is already a Rack env
+    #   (in which case they are dropped)
     #
     # @return [Hanami::Routing::RecognizedRoute] the recognized route
     #
+    # @note String-keyed Rack env entries (e.g. `"HTTP_AUTHORIZATION"`) cannot
+    #   be passed as kwargs. Build the env via `Rack::MockRequest.env_for` and
+    #   pass it as `target` instead.
+    #
     # @since 0.5.0
     #
-    # @see Hanami::Router#env_for
     # @see Hanami::Routing::RecognizedRoute
     #
     # @example Successful Path Recognition
@@ -570,7 +575,7 @@ module Hanami
     #     get "/books/:id", to: ->(*) { ... }, as: :book
     #   end
     #
-    #   route = router.recognize(:book, id: 23)
+    #   route = router.recognize(:book, params: {id: 23})
     #   route.verb      # => "GET" (default)
     #   route.routable? # => true
     #   route.params    # => {:id=>"23"}
@@ -608,7 +613,7 @@ module Hanami
     #   route.verb      # => "POST"
     #   route.routable? # => false
     #
-    # @example Failing Recognition Named Route With Wrong Params
+    # @example Failing Recognition For Named Route With Missing Params
     #   require "hanami/router"
     #
     #   router = Hanami::Router.new do
@@ -619,21 +624,21 @@ module Hanami
     #   route.verb      # => "GET" (default)
     #   route.routable? # => false
     #
-    # @example Failing Recognition Named Route With Wrong HTTP Verb
+    # @example Failing Recognition For Named Route With Wrong HTTP Verb
     #   require "hanami/router"
     #
     #   router = Hanami::Router.new do
     #     get "/books/:id", to: ->(*) { ... }, as: :book
     #   end
     #
-    #   route = router.recognize(:book, {method: :post}, {id: 1})
+    #   route = router.recognize(:book, params: {id: 1}, method: :post)
     #   route.verb      # => "POST"
     #   route.routable? # => false
     #   route.params    # => {:id=>"1"}
-    def recognize(env, params = {}, options = {})
+    def recognize(target, params: {}, **options)
       require "hanami/router/recognized_route"
 
-      env = env_for(env, params, options)
+      env = env_for(target, params: params, **options)
       endpoint, params = lookup(env)
 
       RecognizedRoute.new(endpoint, _params(env, params))
@@ -684,11 +689,12 @@ module Hanami
 
     protected
 
-    # Fabricate Rack env for the given Rack env, path or named route
+    # Fabricate a Rack env for the given target.
     #
-    # @param env [Hash, String, Symbol] Rack env, path or route name
-    # @param options [Hash] a set of options for Rack env or route params
-    # @param params [Hash] a set of params
+    # @param target [String, Symbol, Hash] target (Rack env hash, path, or route name)
+    # @param params [Hash] named-route variables used to build the path
+    # @param options [Hash] Rack env options forwarded to
+    #   `Rack::MockRequest.env_for`
     #
     # @return [Hash] Rack env
     #
@@ -697,21 +703,20 @@ module Hanami
     #
     # @see Hanami::Router#recognize
     # @see http://www.rubydoc.info/github/rack/rack/Rack%2FMockRequest.env_for
-    def env_for(env, params = {}, options = {})
+    def env_for(target, params: {}, **options)
       require "rack/mock"
 
-      case env
+      case target
       when ::String
-        ::Rack::MockRequest.env_for(env, options)
+        ::Rack::MockRequest.env_for(target, options)
       when ::Symbol
         begin
-          url = path(env, params)
-          return env_for(url, params, options) # rubocop:disable Style/RedundantReturn
+          env_for(path(target, params), **options)
         rescue Hanami::Router::MissingRouteError
           {} # Empty Rack env
         end
       else
-        env
+        target
       end
     end
 

--- a/lib/hanami/router/version.rb
+++ b/lib/hanami/router/version.rb
@@ -8,6 +8,6 @@ module Hanami
     #
     # @since 0.1.0
     # @api public
-    VERSION = "2.3.1"
+    VERSION = "3.0.0"
   end
 end

--- a/spec/unit/hanami/router/recognize_spec.rb
+++ b/spec/unit/hanami/router/recognize_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Hanami::Router do
       end
 
       it "returns not routeable result when cannot recognize" do
-        route = router.recognize("/", {}, method: :post)
+        route = router.recognize("/", method: :post)
 
         expect(route.routable?).to be(false)
         expect(route.redirect?).to be(false)
@@ -260,7 +260,7 @@ RSpec.describe Hanami::Router do
 
       it "raises error if #call is invoked for not routeable object when cannot recognize" do
         env   = Rack::MockRequest.env_for("/", method: :post)
-        route = router.recognize("/", {}, method: :post)
+        route = router.recognize("/", method: :post)
 
         expect { route.call(env) }.to raise_error(Hanami::Router::NotRoutableEndpointError, "Cannot find routable endpoint for: POST /")
       end
@@ -298,7 +298,7 @@ RSpec.describe Hanami::Router do
       end
 
       it "recognizes procs with params" do
-        route = router.recognize(:params, id: 1)
+        route = router.recognize(:params, params: {id: 1})
 
         expect(route.routable?).to be(true)
         expect(route.redirect?).to be(false)
@@ -354,7 +354,7 @@ RSpec.describe Hanami::Router do
       end
 
       it "returns not routeable result when cannot recognize" do
-        route = router.recognize(:home, {}, method: :post)
+        route = router.recognize(:home, method: :post)
 
         expect(route.routable?).to be(false)
         expect(route.redirect?).to be(false)
@@ -381,9 +381,57 @@ RSpec.describe Hanami::Router do
 
       it "raises error if #call is invoked for not routeable object when cannot recognize" do
         env   = Rack::MockRequest.env_for("/", method: :post)
-        route = router.recognize(:home, {}, method: :post)
+        route = router.recognize(:home, method: :post)
 
         expect { route.call(env) }.to raise_error(Hanami::Router::NotRoutableEndpointError, "Cannot find routable endpoint for: POST /")
+      end
+    end
+
+    # See: https://github.com/hanami/hanami-router/issues/271
+    context "when forwarding method: kwarg to env_for" do
+      let(:router) do
+        Hanami::Router.new do
+          get    "/images",      to: ->(*) { [200, {}, ["INDEX"]] }
+          post   "/images",      to: ->(*) { [200, {}, ["UPLOAD"]] }
+          get    "/images/:id",  to: ->(*) { [200, {}, ["SHOW"]] }
+          post   "/images/bulk", to: ->(*) { [200, {}, ["BULK"]] }
+          put    "/images/:id",  to: ->(*) { [200, {}, ["REPLACE"]] }, as: :replace
+        end
+      end
+
+      it "recognizes a POST route by path" do
+        route = router.recognize("/images/bulk", method: "POST")
+
+        expect(route.routable?).to be(true)
+        expect(route.verb).to eq("POST")
+        expect(route.path).to eq("/images/bulk")
+        expect(route.params).to eq({})
+      end
+
+      it "accepts a symbol method value" do
+        route = router.recognize("/images", method: :post)
+
+        expect(route.routable?).to be(true)
+        expect(route.verb).to eq("POST")
+        expect(route.path).to eq("/images")
+      end
+
+      it "recognizes a PUT route with path variables" do
+        route = router.recognize("/images/1", method: :put)
+
+        expect(route.routable?).to be(true)
+        expect(route.verb).to eq("PUT")
+        expect(route.path).to eq("/images/1")
+        expect(route.params).to eq(id: "1")
+      end
+
+      it "recognizes a named route with params and method" do
+        route = router.recognize(:replace, params: {id: 1}, method: :put)
+
+        expect(route.routable?).to be(true)
+        expect(route.verb).to eq("PUT")
+        expect(route.path).to eq("/images/1")
+        expect(route.params).to eq(id: "1")
       end
     end
   end


### PR DESCRIPTION
Fixes #271. 

`Router#recognize` was silently ignoring the `method:` kwarg when called without an explicit `params` hash, returning the verb as GET for POST routes and often picking the wrong route.

Root cause: the old signature `recognize(env, params = {}, options = {})` absorbed `method: :post` into the positional `params` argument, leaving `options` empty when it was handed to `Rack::MockRequest.env_for`.

Fixes the bug by moving to an explicit kwargs signature:

```ruby
# Before
def recognize(env, params = {}, options = {})

# After
def recognize(target, params: {}, **options)
```

I also renamed `env` to `target` to reflect that the argument accepts a path, a route name, or a Rack env hash.

This is a breaking change, so will need to be for hanami-router v3. It seems like a good time to fix this "the right way" instead of making a backward-compatible fix that we'd have to continue to maintain. This new approach is much more explicit.

There's a slight behavior change in that we double splat the keyword args, so they're converted to symbols, so e.g. "HTTP_AUTHORIZATION" will get converted to a symbol, which Rack drops. There's a very simple fix though: callers who need this can build the env explicitly via Rack::MockRequest.env_for and pass it in as the target.

_I worked with Claude Code to get this fixed, refactored, and all of the documentation updated._