### PR TITLE
Require explicit `code:` on redirect, add helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ Rack compatible HTTP router for Ruby.
 
 ### Added
 
+- `#permanent_redirect` and `#temporary_redirect` helpers for 301 and 302 responses. (@cllns in #283)
+
 ### Changed
+
+- **BREAKING:** `#redirect` now requires an explicit `code:` keyword argument. Use `#permanent_redirect` or `#temporary_redirect` for the common cases, and pass `code:` to `#redirect` for less common codes (303, 307, 308). (@cllns in #283)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Hanami::Router.new do
   get "/dashboard",   to: Dashboard::Index
   get "/rack-app",    to: RackApp.new
 
-  redirect "/legacy", to: "/"
+  permanent_redirect "/legacy", to: "/"
 
   mount Api::App, at: "/api"
 
@@ -146,9 +146,13 @@ end
 ```ruby
 Hanami::Router.new do
   get "/redirect_destination", to: ->(env) { [200, {}, ["Redirect destination!"]] }
-  redirect "/legacy",          to: "/redirect_destination"
-  redirect "/learn-more",      to: "https://hanamirb.org/"
-  redirect "/chat",            to: URI("xmpp://myapp.net/")
+  permanent_redirect "/legacy",     to: "/redirect_destination"
+  temporary_redirect "/today",      to: "/redirect_destination"
+  permanent_redirect "/learn-more", to: "https://hanamirb.org/"
+  permanent_redirect "/chat",       to: URI("xmpp://myapp.net/")
+
+  # For less common codes (303, 307, 308), use redirect with an explicit code:
+  redirect "/submit", to: "/result", code: 303
 end
 ```
 

--- a/README.repo.md
+++ b/README.repo.md
@@ -55,7 +55,7 @@ Hanami::Router.new do
   get "/dashboard",   to: Dashboard::Index
   get "/rack-app",    to: RackApp.new
 
-  redirect "/legacy", to: "/"
+  permanent_redirect "/legacy", to: "/"
 
   mount Api::App, at: "/api"
 
@@ -134,9 +134,13 @@ end
 ```ruby
 Hanami::Router.new do
   get "/redirect_destination", to: ->(env) { [200, {}, ["Redirect destination!"]] }
-  redirect "/legacy",          to: "/redirect_destination"
-  redirect "/learn-more",      to: "https://hanamirb.org/"
-  redirect "/chat",            to: URI("xmpp://myapp.net/")
+  permanent_redirect "/legacy",     to: "/redirect_destination"
+  temporary_redirect "/today",      to: "/redirect_destination"
+  permanent_redirect "/learn-more", to: "https://hanamirb.org/"
+  permanent_redirect "/chat",       to: URI("xmpp://myapp.net/")
+
+  # For less common codes (303, 307, 308), use redirect with an explicit code:
+  redirect "/submit", to: "/result", code: 303
 end
 ```
 

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -380,20 +380,68 @@ module Hanami
 
     # Defines a route that redirects the incoming request to another path.
     #
+    # `code:` is required. For the common cases, prefer {#permanent_redirect} (301)
+    # or {#temporary_redirect} (302). Use this method when you need a less common
+    # redirect code such as 303 See Other, 307 Temporary Redirect, or 308 Permanent Redirect.
+    #
     # @param path [String] the relative URL to be matched
     # @param to [#call] the Rack endpoint
     # @param as [Symbol, Array<Symbol>] a unique name for the route, or a ["prefix", "name"] array,
     #   to add a prefix to the name when nested within scopes.
-    # @param code [Integer] a HTTP status code to use for the redirect
+    # @param code [Integer] the HTTP status code to use for the redirect (e.g. 303, 307, 308)
     #
     # @raise [Hanami::Router::UnknownHTTPStatusCodeError] when an unknown redirect code is given
     #
     # @since 0.1.0
     #
-    # @see #get
-    # @see #initialize
-    def redirect(path, to: nil, as: nil, code: DEFAULT_REDIRECT_CODE)
+    # @see #permanent_redirect
+    # @see #temporary_redirect
+    def redirect(path, code:, to: nil, as: nil)
       get(path, to: _redirect(to, code), as: as)
+    end
+
+    # Defines a route that permanently redirects the incoming request to another path.
+    #
+    # Issues a 301 Moved Permanently response, indicating that the resource has moved to
+    # a new location and all future requests should use the new URL.
+    #
+    # NOTE: Browsers cache permanent redirects aggressively. Once a client has followed
+    # a 301, it may not re-request the original URL, making the redirect hard to undo
+    # without clearing the browser cache. Prefer {#temporary_redirect} when in doubt.
+    #
+    # @param path [String] the relative URL to be matched
+    # @param to [#call] the Rack endpoint
+    # @param as [Symbol, Array<Symbol>] a unique name for the route, or a ["prefix", "name"] array,
+    #   to add a prefix to the name when nested within scopes.
+    #
+    # @raise [Hanami::Router::UnknownHTTPStatusCodeError] when an unknown redirect code is given
+    #
+    # @since 3.0.0
+    #
+    # @see #redirect
+    # @see #temporary_redirect
+    def permanent_redirect(path, to: nil, as: nil)
+      get(path, to: _redirect(to, PERMANENT_REDIRECT_CODE), as: as)
+    end
+
+    # Defines a route that temporarily redirects the incoming request to another path.
+    #
+    # Issues a 302 Found response, indicating that the resource is temporarily available
+    # at a different URL and future requests should continue to use the original URL.
+    #
+    # @param path [String] the relative URL to be matched
+    # @param to [#call] the Rack endpoint
+    # @param as [Symbol, Array<Symbol>] a unique name for the route, or a ["prefix", "name"] array,
+    #   to add a prefix to the name when nested within scopes.
+    #
+    # @raise [Hanami::Router::UnknownHTTPStatusCodeError] when an unknown redirect code is given
+    #
+    # @since 3.0.0
+    #
+    # @see #redirect
+    # @see #permanent_redirect
+    def temporary_redirect(path, to: nil, as: nil)
+      get(path, to: _redirect(to, TEMPORARY_REDIRECT_CODE), as: as)
     end
 
     # Defines a routing scope. Routes defined in the context of a scope,
@@ -745,9 +793,13 @@ module Hanami
     # @api private
     DEFAULT_RESOLVER = ->(_, to) { to }
 
-    # @since 2.0.0
+    # @since 3.0.0
     # @api private
-    DEFAULT_REDIRECT_CODE = 301
+    PERMANENT_REDIRECT_CODE = 301
+
+    # @since 3.0.0
+    # @api private
+    TEMPORARY_REDIRECT_CODE = 302
 
     # @since 2.0.0
     # @api private

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -394,8 +394,8 @@ module Hanami
     #
     # @since 0.1.0
     #
-    # @see #permanent_redirect
-    # @see #temporary_redirect
+    # @see #redirect_permanent
+    # @see #redirect_temporary
     def redirect(path, code:, to: nil, as: nil)
       get(path, to: _redirect(to, code), as: as)
     end
@@ -407,7 +407,7 @@ module Hanami
     #
     # NOTE: Browsers cache permanent redirects aggressively. Once a client has followed
     # a 301, it may not re-request the original URL, making the redirect hard to undo
-    # without clearing the browser cache. Prefer {#temporary_redirect} when in doubt.
+    # without clearing the browser cache. Prefer {#redirect_temporary} when in doubt.
     #
     # @param path [String] the relative URL to be matched
     # @param to [#call] the Rack endpoint
@@ -419,8 +419,8 @@ module Hanami
     # @since 3.0.0
     #
     # @see #redirect
-    # @see #temporary_redirect
-    def permanent_redirect(path, to: nil, as: nil)
+    # @see #redirect_temporary
+    def redirect_permanent(path, to: nil, as: nil)
       get(path, to: _redirect(to, PERMANENT_REDIRECT_CODE), as: as)
     end
 
@@ -439,8 +439,8 @@ module Hanami
     # @since 3.0.0
     #
     # @see #redirect
-    # @see #permanent_redirect
-    def temporary_redirect(path, to: nil, as: nil)
+    # @see #redirect_permanent
+    def redirect_temporary(path, to: nil, as: nil)
       get(path, to: _redirect(to, TEMPORARY_REDIRECT_CODE), as: as)
     end
 

--- a/spec/integration/hanami/router/prefix_option_spec.rb
+++ b/spec/integration/hanami/router/prefix_option_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Hanami::Router do
 
     it "redirect works with prefix" do
       subject = described_class.new(prefix: prefix) do
-        redirect "/redirect", to: "/redirect_destination"
+        redirect "/redirect", to: "/redirect_destination", code: 301
         get "/redirect_destination", to: ->(*) { [200, {}, ["Redirect destination!"]] }
       end
 

--- a/spec/integration/hanami/router/scope_spec.rb
+++ b/spec/integration/hanami/router/scope_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Hanami::Router do
         router = described_class.new do
           scope "users" do
             scope "settings" do
-              redirect "/image", to: "/avatar"
+              redirect "/image", to: "/avatar", code: 301
             end
           end
         end
@@ -97,7 +97,7 @@ RSpec.describe Hanami::Router do
         described_class.new do
           scope "users" do
             get "/home", to: ->(*) { [200, {}, ["New Home!"]] }
-            redirect "/dashboard", to: "/home"
+            redirect "/dashboard", to: "/home", code: 301
           end
         end
       end

--- a/spec/unit/hanami/router/recognize_spec.rb
+++ b/spec/unit/hanami/router/recognize_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hanami::Router do
         get "/proc",          to: ->(*) { [200, {}, ["OK"]] },                                          as: :proc
         get "/resources/:id", to: ->(*) { [200, {}, ["PARAMS"]] },                                      as: :params
         get "/missing",       to: "missing#index",                                                      as: :missing
-        redirect "/home",     to: "/"
+        redirect "/home",     to: "/", code: 301
       end
     end
 

--- a/spec/unit/hanami/router/redirect_spec.rb
+++ b/spec/unit/hanami/router/redirect_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::Router do
-  describe "#redirect" do
-    it "recognizes string endpoint" do
+  describe "#permanent_redirect" do
+    it "redirects with 301" do
       endpoint = ->(_env) { [200, {}, ["Redirect destination!"]] }
-      router   = Hanami::Router.new do
+      router = Hanami::Router.new do
         get "/redirect_destination", to: endpoint, as: :destination
-        redirect "/redirect", to: "/redirect_destination"
+        permanent_redirect "/redirect", to: "/redirect_destination"
       end
 
       env = Rack::MockRequest.env_for("/redirect")
@@ -16,11 +16,25 @@ RSpec.describe Hanami::Router do
       expect(headers[Hanami::Router::HTTP_HEADER_LOCATION]).to eq("/redirect_destination")
     end
 
-    it "recognizes string endpoint with custom http code" do
+    it "redirects to an absolute url" do
+      router = Hanami::Router.new do
+        permanent_redirect "/redirect", to: "https://hanamirb.org/"
+      end
+
+      env = Rack::MockRequest.env_for("/redirect")
+      status, headers, = router.call(env)
+
+      expect(status).to eq(301)
+      expect(headers[Hanami::Router::HTTP_HEADER_LOCATION]).to eq("https://hanamirb.org/")
+    end
+  end
+
+  describe "#temporary_redirect" do
+    it "redirects with 302" do
       endpoint = ->(_env) { [200, {}, ["Redirect destination!"]] }
       router = Hanami::Router.new do
-        get "/redirect_destination", to: endpoint
-        redirect "/redirect", to: "/redirect_destination", code: 302
+        get "/redirect_destination", to: endpoint, as: :destination
+        temporary_redirect "/redirect", to: "/redirect_destination"
       end
 
       env = Rack::MockRequest.env_for("/redirect")
@@ -30,41 +44,73 @@ RSpec.describe Hanami::Router do
       expect(headers[Hanami::Router::HTTP_HEADER_LOCATION]).to eq("/redirect_destination")
     end
 
-    it "recognizes string endpoint with absolute url" do
+    it "redirects to an absolute url" do
       router = Hanami::Router.new do
-        redirect "/redirect", to: "https://hanamirb.org/"
+        temporary_redirect "/redirect", to: "https://hanamirb.org/"
       end
 
       env = Rack::MockRequest.env_for("/redirect")
       status, headers, = router.call(env)
 
-      expect(status).to eq(301)
+      expect(status).to eq(302)
       expect(headers[Hanami::Router::HTTP_HEADER_LOCATION]).to eq("https://hanamirb.org/")
     end
+  end
 
-    it "recognizes string endpoint with relative path that start like an absolute url but is not" do
+  describe "#redirect" do
+    it "requires code:" do
+      expect {
+        Hanami::Router.new do
+          redirect "/redirect", to: "/redirect_destination"
+        end
+      }.to raise_error(ArgumentError, /missing keyword: :?code/)
+    end
+
+    it "redirects with the given code" do
+      endpoint = ->(_env) { [200, {}, ["Redirect destination!"]] }
+      router = Hanami::Router.new do
+        get "/redirect_destination", to: endpoint, as: :destination
+        redirect "/redirect", to: "/redirect_destination", code: 307
+      end
+
+      env = Rack::MockRequest.env_for("/redirect")
+      status, headers, = router.call(env)
+
+      expect(status).to eq(307)
+      expect(headers[Hanami::Router::HTTP_HEADER_LOCATION]).to eq("/redirect_destination")
+    end
+
+    it "raises UnknownHTTPStatusCodeError for an unknown code" do
+      expect {
+        Hanami::Router.new do
+          redirect "/redirect", to: "/redirect_destination", code: 999
+        end
+      }.to raise_error(Hanami::Router::UnknownHTTPStatusCodeError, /999/)
+    end
+
+    it "recognizes relative path that starts like an absolute url but is not" do
       endpoint = ->(_env) { [200, {}, ["Redirect destination!"]] }
       router = Hanami::Router.new do
         get "/http:redirect_destination", to: endpoint, as: :destination
-        redirect "/redirect", to: "/http:redirect_destination"
+        redirect "/redirect", to: "/http:redirect_destination", code: 303
       end
 
       env = Rack::MockRequest.env_for("/redirect")
       status, headers, = router.call(env)
 
-      expect(status).to eq(301)
+      expect(status).to eq(303)
       expect(headers[Hanami::Router::HTTP_HEADER_LOCATION]).to eq("/http:redirect_destination")
     end
 
     it "recognizes URI endpoint" do
       router = Hanami::Router.new do
-        redirect "/redirect", to: URI("custom://hanamirb.org/1234")
+        redirect "/redirect", to: URI("custom://hanamirb.org/1234"), code: 308
       end
 
       env = Rack::MockRequest.env_for("/redirect")
       status, headers, = router.call(env)
 
-      expect(status).to eq(301)
+      expect(status).to eq(308)
       expect(headers[Hanami::Router::HTTP_HEADER_LOCATION]).to eq("custom://hanamirb.org/1234")
     end
   end

--- a/spec/unit/hanami/router/redirect_spec.rb
+++ b/spec/unit/hanami/router/redirect_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::Router do
-  describe "#permanent_redirect" do
+  describe "#redirect_permanent" do
     it "redirects with 301" do
       endpoint = ->(_env) { [200, {}, ["Redirect destination!"]] }
       router = Hanami::Router.new do
         get "/redirect_destination", to: endpoint, as: :destination
-        permanent_redirect "/redirect", to: "/redirect_destination"
+        redirect_permanent "/redirect", to: "/redirect_destination"
       end
 
       env = Rack::MockRequest.env_for("/redirect")
@@ -18,7 +18,7 @@ RSpec.describe Hanami::Router do
 
     it "redirects to an absolute url" do
       router = Hanami::Router.new do
-        permanent_redirect "/redirect", to: "https://hanamirb.org/"
+        redirect_permanent "/redirect", to: "https://hanamirb.org/"
       end
 
       env = Rack::MockRequest.env_for("/redirect")
@@ -29,12 +29,12 @@ RSpec.describe Hanami::Router do
     end
   end
 
-  describe "#temporary_redirect" do
+  describe "#redirect_temporary" do
     it "redirects with 302" do
       endpoint = ->(_env) { [200, {}, ["Redirect destination!"]] }
       router = Hanami::Router.new do
         get "/redirect_destination", to: endpoint, as: :destination
-        temporary_redirect "/redirect", to: "/redirect_destination"
+        redirect_temporary "/redirect", to: "/redirect_destination"
       end
 
       env = Rack::MockRequest.env_for("/redirect")
@@ -46,7 +46,7 @@ RSpec.describe Hanami::Router do
 
     it "redirects to an absolute url" do
       router = Hanami::Router.new do
-        temporary_redirect "/redirect", to: "https://hanamirb.org/"
+        redirect_temporary "/redirect", to: "https://hanamirb.org/"
       end
 
       env = Rack::MockRequest.env_for("/redirect")


### PR DESCRIPTION
Closes #283

Removes the default 301 from redirect and requires `code:` explicitly. 

Adds `permanent_redirect` (301) and `temporary_redirect` (302) helpers for the common cases. 

This is a breaking change, since it requires `code:` kwarg (so will have to target v3.0+), whereas now we default to 301. I'm also open to having 302 as the default and *not* requiring it, but «there are worse things than being explicit». 

_I worked with Claude Code to implement this and update the docs accordingly._