### PR TITLE
Add array variables extraction + injection around Mustermann expand method

### DIFF
--- a/lib/hanami/router/url_helpers.rb
+++ b/lib/hanami/router/url_helpers.rb
@@ -28,9 +28,16 @@ module Hanami
       # @since 2.0.0
       # @api private
       def path(name, variables = {})
-        @named.fetch(name.to_sym) do
+        safe_variables = variables.reject do |key, value|
+          value.is_a?(Array)
+        end
+        array_variables = extract_and_patch_array_variables(variables)
+
+        expanded_path = @named.fetch(name.to_sym) do
           raise MissingRouteError.new(name)
-        end.expand(:append, variables)
+        end.expand(:append, safe_variables)
+
+        append_array_variables(expanded_path, array_variables)
       rescue Mustermann::ExpandError => exception
         raise InvalidRouteExpansionError.new(name, exception.message)
       end
@@ -39,6 +46,28 @@ module Hanami
       # @api private
       def url(name, variables = {})
         @base_url + @prefix.join(path(name, variables)).to_s
+      end
+
+      # @since 2.3.3
+      # @api private
+      def extract_and_patch_array_variables(variables = {})
+        variables.select do |key, value|
+          value.is_a?(Array)
+        end.to_h do |key, value|
+          ["#{key}[]", value]
+        end
+      end
+
+      # @since 2.3.3
+      # @api private
+      def append_array_variables(expanded_path, array_variables)
+        if array_variables.empty?
+          expanded_path
+        else
+          array_query = Rack::Utils.build_query(array_variables)
+          join_char = expanded_path =~ /\?/ ? "&" : "?"
+          "#{expanded_path}#{join_char}#{array_query}"
+        end
       end
     end
   end

--- a/lib/hanami/router/url_helpers.rb
+++ b/lib/hanami/router/url_helpers.rb
@@ -6,7 +6,6 @@ require_relative "prefix"
 
 module Hanami
   class Router
-    # @since 2.0.0
     # @api private
     class UrlHelpers
       # @since 2.0.0
@@ -19,55 +18,39 @@ module Hanami
         @prefix = Prefix.new(prefix)
       end
 
-      # @since 2.0.0
       # @api private
       def add(name, segment)
         @named[name] = segment
       end
 
-      # @since 2.0.0
       # @api private
       def path(name, variables = {})
-        safe_variables = variables.reject do |key, value|
-          value.is_a?(Array)
-        end
-        array_variables = extract_and_patch_array_variables(variables)
+        scalar_vars = variables.reject { |_, value| value.is_a?(Array) }
+        array_vars = array_query_vars(variables)
 
-        expanded_path = @named.fetch(name.to_sym) do
-          raise MissingRouteError.new(name)
-        end.expand(:append, safe_variables)
+        expanded_path = @named
+          .fetch(name.to_sym) { raise MissingRouteError.new(name) }
+          .expand(:append, scalar_vars)
 
-        append_array_variables(expanded_path, array_variables)
+        return expanded_path if array_vars.empty?
+
+        join_char = expanded_path.include?("?") ? "&" : "?"
+        "#{expanded_path}#{join_char}#{Rack::Utils.build_query(array_vars)}"
       rescue Mustermann::ExpandError => exception
         raise InvalidRouteExpansionError.new(name, exception.message)
       end
 
-      # @since 2.0.0
       # @api private
       def url(name, variables = {})
         @base_url + @prefix.join(path(name, variables)).to_s
       end
 
-      # @since 2.3.3
-      # @api private
-      def extract_and_patch_array_variables(variables = {})
-        variables.select do |key, value|
-          value.is_a?(Array)
-        end.to_h do |key, value|
-          ["#{key}[]", value]
-        end
-      end
+      private
 
-      # @since 2.3.3
-      # @api private
-      def append_array_variables(expanded_path, array_variables)
-        if array_variables.empty?
-          expanded_path
-        else
-          array_query = Rack::Utils.build_query(array_variables)
-          join_char = expanded_path =~ /\?/ ? "&" : "?"
-          "#{expanded_path}#{join_char}#{array_query}"
-        end
+      def array_query_vars(variables = {})
+        variables
+          .select { |_, value| value.is_a?(Array) }
+          .to_h { |key, value| ["#{key}[]", value] }
       end
     end
   end

--- a/spec/integration/hanami/router/routing_spec.rb
+++ b/spec/integration/hanami/router/routing_spec.rb
@@ -111,6 +111,24 @@ RSpec.describe Hanami::Router do
             end
           end
 
+          context "array variable alone" do
+            let(:response) { Rack::MockResponse.new(200, rack_headers({}), "Named %route!") }
+
+            it "recognizes" do
+              expect(router.path(:"#{verb}_named_route", foo: ["bar", "baz"])).to eq("/named_route?foo%5B%5D=bar&foo%5B%5D=baz")
+              expect(router.url(:"#{verb}_named_route", foo: ["bar", "baz"])).to  eq(URI("http://localhost/named_route?foo%5B%5D=bar&foo%5B%5D=baz"))
+            end
+          end
+
+          context "array variable mixed" do
+            let(:response) { Rack::MockResponse.new(200, rack_headers({}), "Named %route!") }
+
+            it "recognizes" do
+              expect(router.path(:"#{verb}_named_route", foo: ["bar", "baz"], var: "plop")).to eq("/named_route?var=plop&foo%5B%5D=bar&foo%5B%5D=baz")
+              expect(router.url(:"#{verb}_named_route", foo: ["bar", "baz"], var: "plop")).to  eq(URI("http://localhost/named_route?var=plop&foo%5B%5D=bar&foo%5B%5D=baz"))
+            end
+          end
+
           context "custom url parts" do
             let(:response) { Rack::MockResponse.new(200, rack_headers({}), "Named route with custom parts!") }
 


### PR DESCRIPTION
Trying to fix #303 

It's a bit tricky to handle array query variables as Mustermann handled expansion by itself.

We have to extract array variables of its scope otherwise it will choke on non-array variables

We can add serialized arrays afterwards so that Mustermann is not aware of them


