### PR TITLE
Fix nested form body parsing happening for all content types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Rack compatible HTTP router for Ruby.
 
 ### Fixed
 
+- Only parse the request body into params when the content type is `application/x-www-form-urlencoded`. Previously, with no body parser middleware in use, posting a multipart upload (or other non-form body) could raise `Rack::QueryParser::InvalidParameterError`. (@cllns and @timriley in #305)
+
 ### Security
 
 [Unreleased]: http://github.com/hanami/hanami-router/compare/v3.0.0.rc1...HEAD

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -1040,16 +1040,24 @@ module Hanami
       params ||= {}
       env[PARAMS] ||= {}
 
-      if !env.key?(ROUTER_PARSED_BODY) && _form_urlencoded?(env) && (input = env[::Rack::RACK_INPUT]) and input.rewind
-        env[PARAMS].merge!(::Rack::Utils.parse_nested_query(input.read))
-        input.rewind
-      end
-
+      _merge_form_urlencoded_body!(env)
       env[PARAMS].merge!(::Rack::Utils.parse_nested_query(env[::Rack::QUERY_STRING]))
       env[PARAMS].merge!(params)
       env[PARAMS] = Params.deep_symbolize(env[PARAMS])
 
       env
+    end
+
+    # @since x.x.x
+    # @api private
+    def _merge_form_urlencoded_body!(env)
+      return if env.key?(ROUTER_PARSED_BODY)
+      return unless _form_urlencoded?(env)
+      return unless (input = env[::Rack::RACK_INPUT])
+
+      input.rewind
+      env[PARAMS].merge!(::Rack::Utils.parse_nested_query(input.read))
+      input.rewind # leave the stream readable for downstream consumers
     end
 
     # @since x.x.x

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -1040,7 +1040,7 @@ module Hanami
       params ||= {}
       env[PARAMS] ||= {}
 
-      if !env.key?(ROUTER_PARSED_BODY) && (input = env[::Rack::RACK_INPUT]) and input.rewind
+      if !env.key?(ROUTER_PARSED_BODY) && _form_urlencoded?(env) && (input = env[::Rack::RACK_INPUT]) and input.rewind
         env[PARAMS].merge!(::Rack::Utils.parse_nested_query(input.read))
         input.rewind
       end
@@ -1050,6 +1050,12 @@ module Hanami
       env[PARAMS] = Params.deep_symbolize(env[PARAMS])
 
       env
+    end
+
+    # @since x.x.x
+    # @api private
+    def _form_urlencoded?(env)
+      ::Rack::Request.new(env).media_type == "application/x-www-form-urlencoded"
     end
 
     # @since 2.0.0

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -1055,7 +1055,7 @@ module Hanami
     # @since x.x.x
     # @api private
     def _form_urlencoded?(env)
-      ::Rack::Request.new(env).media_type == "application/x-www-form-urlencoded"
+      ::Rack::Request.new(env).media_type == FORM_URLENCODED_MEDIA_TYPE
     end
 
     # @since 2.0.0

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -787,6 +787,9 @@ module Hanami
     # @api private
     EMPTY_STRING = ""
 
+    # @api private
+    EMPTY_HASH = {}.freeze
+
     # @since 2.0.0
     # @api private
     DEFAULT_RESOLVER = ->(_, to) { to }
@@ -838,6 +841,15 @@ module Hanami
     # @since 2.0.0
     # @api private
     PARAMS = "router.params"
+
+    # @api private
+    CONTENT_TYPE = "CONTENT_TYPE"
+
+    # @api private
+    FORM_URLENCODED_MEDIA_TYPE = "application/x-www-form-urlencoded"
+
+    # @api private
+    FORM_URLENCODED_MEDIA_TYPE_PREFIX = "#{FORM_URLENCODED_MEDIA_TYPE};".freeze
 
     # @since 2.0.0
     # @api private

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -1048,7 +1048,6 @@ module Hanami
       env
     end
 
-    # @since x.x.x
     # @api private
     def _merge_form_urlencoded_body!(env)
       return if env.key?(ROUTER_PARSED_BODY)
@@ -1060,14 +1059,14 @@ module Hanami
       input.rewind # leave the stream readable for downstream consumers
     end
 
-    # @since x.x.x
     # @api private
     def _form_urlencoded?(env)
       content_type = env[CONTENT_TYPE]
       return false unless content_type
 
+      content_type = content_type.downcase
       content_type == FORM_URLENCODED_MEDIA_TYPE ||
-        content_type.start_with?("#{FORM_URLENCODED_MEDIA_TYPE};")
+        content_type.start_with?(FORM_URLENCODED_MEDIA_TYPE_PREFIX)
     end
 
     # @since 2.0.0

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -1063,7 +1063,11 @@ module Hanami
     # @since x.x.x
     # @api private
     def _form_urlencoded?(env)
-      ::Rack::Request.new(env).media_type == FORM_URLENCODED_MEDIA_TYPE
+      content_type = env[CONTENT_TYPE]
+      return false unless content_type
+
+      content_type == FORM_URLENCODED_MEDIA_TYPE ||
+        content_type.start_with?("#{FORM_URLENCODED_MEDIA_TYPE};")
     end
 
     # @since 2.0.0

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -113,9 +113,7 @@ module Hanami
         env[::Rack::RACK_INPUT] = Rack::RewindableInput.new(input)
       end
 
-      endpoint.call(
-        _params(env, params)
-      ).to_a
+      endpoint.call(_env_with_params(env, params)).to_a
     end
 
     # Defines a named root route (a GET route for "/")
@@ -684,7 +682,7 @@ module Hanami
       env = env_for(env, params, options)
       endpoint, params = lookup(env)
 
-      RecognizedRoute.new(endpoint, _params(env, params))
+      RecognizedRoute.new(endpoint, _env_with_params(env, params))
     end
 
     # @since 2.0.0
@@ -1034,9 +1032,8 @@ module Hanami
       Redirect.new(destination, code, ->(*) { [code, {HTTP_HEADER_LOCATION => destination}, [body]] })
     end
 
-    # @since 2.0.0
     # @api private
-    def _params(env, params)
+    def _env_with_params(env, params)
       params ||= {}
       env[PARAMS] ||= {}
 

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -1040,7 +1040,7 @@ module Hanami
       params ||= {}
       env[PARAMS] ||= {}
 
-      _merge_form_urlencoded_body!(env)
+      env[PARAMS].merge!(_form_urlencoded_body(env))
       env[PARAMS].merge!(::Rack::Utils.parse_nested_query(env[::Rack::QUERY_STRING]))
       env[PARAMS].merge!(params)
       env[PARAMS] = Params.deep_symbolize(env[PARAMS])
@@ -1049,14 +1049,15 @@ module Hanami
     end
 
     # @api private
-    def _merge_form_urlencoded_body!(env)
-      return if env.key?(ROUTER_PARSED_BODY)
-      return unless _form_urlencoded?(env)
-      return unless (input = env[::Rack::RACK_INPUT])
+    def _form_urlencoded_body(env)
+      return EMPTY_HASH if env.key?(ROUTER_PARSED_BODY)
+      return EMPTY_HASH unless _form_urlencoded?(env)
+      return EMPTY_HASH unless (input = env[::Rack::RACK_INPUT])
 
       input.rewind
-      env[PARAMS].merge!(::Rack::Utils.parse_nested_query(input.read))
+      body = ::Rack::Utils.parse_nested_query(input.read)
       input.rewind # leave the stream readable for downstream consumers
+      body
     end
 
     # @api private

--- a/lib/hanami/router/constants.rb
+++ b/lib/hanami/router/constants.rb
@@ -5,5 +5,9 @@ module Hanami
     # @api private
     # @since 2.0.0
     ROUTER_PARSED_BODY = "router.parsed_body"
+
+    # @api private
+    # @since x.x.x
+    FORM_URLENCODED_MEDIA_TYPE = "application/x-www-form-urlencoded"
   end
 end

--- a/lib/hanami/router/constants.rb
+++ b/lib/hanami/router/constants.rb
@@ -8,6 +8,10 @@ module Hanami
 
     # @api private
     # @since x.x.x
+    CONTENT_TYPE = "CONTENT_TYPE"
+
+    # @api private
+    # @since x.x.x
     FORM_URLENCODED_MEDIA_TYPE = "application/x-www-form-urlencoded"
   end
 end

--- a/lib/hanami/router/constants.rb
+++ b/lib/hanami/router/constants.rb
@@ -3,15 +3,15 @@
 module Hanami
   class Router
     # @api private
-    # @since 2.0.0
     ROUTER_PARSED_BODY = "router.parsed_body"
 
     # @api private
-    # @since x.x.x
     CONTENT_TYPE = "CONTENT_TYPE"
 
     # @api private
-    # @since x.x.x
     FORM_URLENCODED_MEDIA_TYPE = "application/x-www-form-urlencoded"
+
+    # @api private
+    FORM_URLENCODED_MEDIA_TYPE_PREFIX = "#{FORM_URLENCODED_MEDIA_TYPE};".freeze
   end
 end

--- a/lib/hanami/router/constants.rb
+++ b/lib/hanami/router/constants.rb
@@ -13,5 +13,8 @@ module Hanami
 
     # @api private
     FORM_URLENCODED_MEDIA_TYPE_PREFIX = "#{FORM_URLENCODED_MEDIA_TYPE};".freeze
+
+    # @api private
+    EMPTY_HASH = {}.freeze
   end
 end

--- a/lib/hanami/router/constants.rb
+++ b/lib/hanami/router/constants.rb
@@ -2,19 +2,10 @@
 
 module Hanami
   class Router
+    # Rack env key containing the request body as parsed by the body parser middleware. Signals that
+    # the body has already been parsed, so the router should not attempt to parse it again.
+    #
     # @api private
     ROUTER_PARSED_BODY = "router.parsed_body"
-
-    # @api private
-    CONTENT_TYPE = "CONTENT_TYPE"
-
-    # @api private
-    FORM_URLENCODED_MEDIA_TYPE = "application/x-www-form-urlencoded"
-
-    # @api private
-    FORM_URLENCODED_MEDIA_TYPE_PREFIX = "#{FORM_URLENCODED_MEDIA_TYPE};".freeze
-
-    # @api private
-    EMPTY_HASH = {}.freeze
   end
 end

--- a/spec/integration/hanami/router/params_spec.rb
+++ b/spec/integration/hanami/router/params_spec.rb
@@ -130,6 +130,16 @@ RSpec.describe "Params" do
     end
   end
 
+  context "multipart payload without body parser" do
+    # See: https://github.com/hanami/router/issues/296
+    it "doesn't merge a multipart body into params" do
+      env, _contents = multipart_fixture("foo.xml")
+      subject.call(env)
+
+      expect(env["router.params"]).to eq({})
+    end
+  end
+
   context "priority" do
     it "gives first level priority to path variables" do
       expected = "23"

--- a/spec/integration/hanami/router/params_spec.rb
+++ b/spec/integration/hanami/router/params_spec.rb
@@ -118,6 +118,18 @@ RSpec.describe "Params" do
     end
   end
 
+  context "JSON payload without body parser" do
+    # See: https://github.com/hanami/router/issues/237
+    it "doesn't merge a JSON body into params" do
+      input = JSON.generate("foo" => "bar")
+      env = Rack::MockRequest.env_for("/submit?from=ui", method: "POST", params: input)
+      env["CONTENT_TYPE"] = "application/json"
+      subject.call(env)
+
+      expect(env["router.params"]).to eq(from: "ui")
+    end
+  end
+
   context "priority" do
     it "gives first level priority to path variables" do
       expected = "23"

--- a/spec/integration/hanami/router/params_spec.rb
+++ b/spec/integration/hanami/router/params_spec.rb
@@ -121,9 +121,12 @@ RSpec.describe "Params" do
   context "JSON payload without body parser" do
     # See: https://github.com/hanami/router/issues/237
     it "doesn't merge a JSON body into params" do
-      input = JSON.generate("foo" => "bar")
-      env = Rack::MockRequest.env_for("/submit?from=ui", method: "POST", params: input)
-      env["CONTENT_TYPE"] = "application/json"
+      env = Rack::MockRequest.env_for(
+        "/submit?from=ui",
+        method: "POST",
+        input: JSON.generate("foo" => "bar"),
+        "CONTENT_TYPE" => "application/json"
+      )
       subject.call(env)
 
       expect(env["router.params"]).to eq(from: "ui")


### PR DESCRIPTION
I have a JSON API Hanami app and when benchmarking it, I had some generated code that POSTed with "%" in a field, as in "Improves speeds by 50%". This surprisingly raised a `Rack::QueryParser::InvalidParameterError`.

This is because we run `Rack::Utils.parse_nested_query` on the request body for _every_ request, regardless of Content-Type. This causes JSON bodies to leak into router.params (as evidenced by the JSON regression test failure added here: `{from: "ui", "{\"foo\":\"bar\"}": nil}`), while bodies containing a literal `%` (#237) or multipart binary bytes (#296, other regression test) raise `Rack::QueryParser::InvalidParameterError` because it's being parsed as form input (nested query) and the % is interpreted as malformed URL encoding.

#237 was closed with #240 as the workaround, but that was at a different time in the frameworks history: when we required JSON parsing to be done via a body parser in this repo. Now we're more flexible and parse it later on, so the problem gets triggered upstream. This fixes it at its proper place, only using `::Rack::Utils.parse_nested_query` for forms.

Closes #296